### PR TITLE
[feat]: 사진첩 페이지 디자인 변경 (#49)

### DIFF
--- a/src/pages/photo/PhotoDetail.js
+++ b/src/pages/photo/PhotoDetail.js
@@ -42,9 +42,9 @@ const PhotoDetail = () => {
     <div className="photo-detail-content">
       {loading ? (
         <div>
-          <p style={{ justifyContent: "center", fontSize: "30px" }}>
+          <h3 style={{ justifyContent: "center", fontSize: "30px" }}>
             {article.title}{" "}
-          </p>
+          </h3>
           <p>
             {"   "}
             {article.author} | {createDt}
@@ -163,14 +163,27 @@ const PhotoDetail = () => {
           <hr />
 
           <p>{article.content}</p>
-          <Button
-            variant="primary"
-            onClick={() => {
-              navigate("../photo");
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              marginTop: "50px",
             }}
           >
-            글 목록
-          </Button>
+            <button
+              className="w3-bar-item w3-button"
+              style={{
+                background: "#6a81ed",
+                width: "130px",
+                padding: "10px 0px 10px 0px",
+              }}
+              onClick={() => {
+                navigate("../photo");
+              }}
+            >
+              글 목록
+            </button>
+          </div>
         </div>
       ) : (
         <div></div>

--- a/src/pages/photo/PhotoDetail.scss
+++ b/src/pages/photo/PhotoDetail.scss
@@ -1,6 +1,7 @@
 .photo-detail-content {
   padding: 10px 200px;
   margin-bottom: 10rem;
+  margin-top: 5rem;
 
   .show-imageList {
     margin-bottom: 30px;

--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -107,10 +107,13 @@ const PhotoList = () => {
                         "/files/" +
                         list.files[0].filePath
                       }
-                      style={{ width: "100%", height: "100%" }}
+                      style={{ width: "100%", height: "230px" }}
                     ></img>
                     <br />
-                    {list.title}
+                    <br />
+                    <h4>
+                      <strong>{list.title}</strong>
+                    </h4>
                     <hr />
                     {list.author} | {createDt}
                   </div>

--- a/src/pages/photo/PhotoList.scss
+++ b/src/pages/photo/PhotoList.scss
@@ -1,6 +1,5 @@
 .photoMain {
   background-color: rgb(255, 255, 255);
-  padding-left: 10%;
-  padding-right: 10%;
+  justify-content: center;
   padding-bottom: 5rem;
 }

--- a/src/pages/photo/PhotoPage.js
+++ b/src/pages/photo/PhotoPage.js
@@ -6,6 +6,8 @@ import { useNavigate } from "react-router-dom";
 import { getCookie } from "../../hooks/useCookie";
 import Swal from "sweetalert2";
 
+import photo from "../../imgs/banner/photo.jpg";
+
 function PhotoPage() {
   const navigate = useNavigate();
   const [authorizationValue, setAuthorizationValue] = useState("");
@@ -51,15 +53,29 @@ function PhotoPage() {
   };
 
   return (
-    <div className="container">
-      <Button
-        variant="primary"
-        onClick={() => {
-          photoUpload();
-        }}
+    <div
+      className="container"
+      style={{
+        width: "80%",
+        marginTop: "150px",
+      }}
+    >
+      <img src={photo} style={{ width: "100%", height: "200px" }}></img>
+      <div
+        style={{ display: "flex", justifyContent: "right", marginTop: "50px" }}
       >
-        글쓰기
-      </Button>
+        <button
+          className="w3-bar-item w3-button"
+          style={{
+            background: "#6a81ed",
+            width: "130px",
+            padding: "10px 0px 10px 0px",
+          }}
+          onClick={photoUpload}
+        >
+          글쓰기
+        </button>
+      </div>
       <PhotoList />
     </div>
   );


### PR DESCRIPTION
## 👀 이슈

resolve #49 

## 📌 개요

사진첩 페이지 디자인을 변경합니다.

## 👩‍💻 작업 사항

- 사진첩 배너 추가합니다.
- 대표사진 이미지 크기를 맞춥니다.
- 여백을 수정합니다.
- 사진첩 글쓰기 버튼 디자인 위치를 변경합니다.

## ✅ 참고 사항

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/57143818/179384135-01ad53af-7697-4ed6-b228-395f7dff3d57.png">

