### PR TITLE
[fix]: 공지사항 디테일 페이지 제목 제대로 뜨도록 수정, 여백 및 크기 수정,  코드 오타 수정

### DIFF
--- a/src/pages/notice/NoticeDetail.scss
+++ b/src/pages/notice/NoticeDetail.scss
@@ -1,31 +1,33 @@
-.NoticeDetail{
-  .container{
+.NoticeDetail {
+  .container {
     display: flex;
     flex-direction: column;
-
+    width: 80%;
+    margin-top: 150px;
     > div {
       padding-left: 1%;
       padding-right: 1%;
     }
   }
 
-  .pageTitle{
+  .pageTitle {
     border-top: 2px solid #000;
     border-bottom: 1px solid #dfdfdf;
-    padding: 17.5px 0 16px
+    padding: 17.5px 0 16px;
   }
 
-  .pageInfo dt, dd {
+  .pageInfo dt,
+  dd {
     float: left;
     margin-right: 15px;
     display: inline;
   }
 
-  .contents{
+  .contents {
     padding: 5% 0px 5% 0px;
   }
 
-  nav{
+  nav {
     border-bottom: 1px solid #dfdfdf;
     margin-bottom: 1.5%;
     div {
@@ -42,12 +44,12 @@
         background-color: #f7f8f9;
         border-right: 1px solid #dfdfdf;
         margin-right: 1.5%;
-        cursor:auto;
+        cursor: auto;
       }
     }
   }
 
-  .catalogue{
+  .catalogue {
     display: flex;
     justify-content: flex-end;
     margin-bottom: 3%;

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { call } from '../../hooks/useFetch';
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { call } from "../../hooks/useFetch";
 
 import "./NoticeDetail.scss";
 
@@ -11,81 +11,122 @@ function NoticeDetailPage() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-
-    call("/api/boards/"+location.state.boardId+"/articles/"+location.state.articleId, "GET").then((response)=>{
+    call(
+      "/api/boards/" +
+        location.state.boardId +
+        "/articles/" +
+        location.state.articleId,
+      "GET"
+    ).then((response) => {
       setArticle(response.response);
       setLoading(true);
-    })
+    });
+  }, []);
 
-  }, [])
-  
   return (
     <div className="NoticeDetail">
-      {loading ? 
-      <div className='container'>
-        
-        <div className="pageTitle">
-          <h3>{location.state.articleId}</h3>
-          <div className="pageInfo">
-            <dl>
-              <dt>작성자 &#58;</dt>
-              <dd>{article.author}	&nbsp; &#124;</dd>
+      {loading ? (
+        <div className="container">
+          <div className="pageTitle">
+            <h3>{article.title}</h3>
+            <div className="pageInfo">
+              <dl>
+                <dt>작성자 &#58;</dt>
+                <dd>{article.author} &nbsp; &#124;</dd>
 
-              <dt>작성일 &#58;</dt>
-              <dd>{article.createDt}	&nbsp; &#124;</dd>
+                <dt>작성일 &#58;</dt>
+                <dd>{article.createDt} &nbsp; &#124;</dd>
 
-              <dt>조회수 &#58;</dt>
-              <dd>{article.viewCnt}</dd>
-            </dl>
+                <dt>조회수 &#58;</dt>
+                <dd>{article.viewCnt}</dd>
+              </dl>
+            </div>
           </div>
-        </div>
-        
-        <div className='contents'>{article.content}</div>
 
+          <div className="contents">{article.content}</div>
 
           <div>
             <nav>
-              <div> <span> <b>&lt;</b> 이전글</span> 이전글입니다 </div>
-              <div> <span> <b>&gt;</b> 다음글</span> 다음글입니다 </div>
+              <div>
+                {" "}
+                <span>
+                  {" "}
+                  <b>&lt;</b> 이전글
+                </span>{" "}
+                이전글입니다{" "}
+              </div>
+              <div>
+                {" "}
+                <span>
+                  {" "}
+                  <b>&gt;</b> 다음글
+                </span>{" "}
+                다음글입니다{" "}
+              </div>
             </nav>
           </div>
-          <div className='catalogue'>
-          <button onClick={() => { navigate('/notice')}}>목록</button>
+          <div className="catalogue">
+            <button
+              onClick={() => {
+                navigate("/notice");
+              }}
+            >
+              목록
+            </button>
           </div>
         </div>
-        :
-        <div className='container'>
-        <div className="pageTitle">
-          <h3>{location.state.id}</h3>
-          <div className="pageInfo">
-            <dl>
-              <dt>작성자 &#58;</dt>
-              <dd>관리자	&nbsp; &#124;</dd>
+      ) : (
+        <div className="container">
+          <div className="pageTitle">
+            <h3>{location.state.id}</h3>
+            <div className="pageInfo">
+              <dl>
+                <dt>작성자 &#58;</dt>
+                <dd>관리자 &nbsp; &#124;</dd>
 
-              <dt>작성일 &#58;</dt>
-              <dd>2022-03-12	&nbsp; &#124;</dd>
+                <dt>작성일 &#58;</dt>
+                <dd>2022-03-12 &nbsp; &#124;</dd>
 
-              <dt>조회수 &#58;</dt>
-              <dd>322</dd>
-            </dl>
+                <dt>조회수 &#58;</dt>
+                <dd>322</dd>
+              </dl>
+            </div>
           </div>
-        </div>
-        
-        <div className='contents'>글 내용</div>
+
+          <div className="contents">글 내용</div>
           <div>
             <nav>
-              <div> <span> <b>&lt;</b> 이전글</span> 이전글입니다 </div>
-              <div> <span> <b>&gt;</b> 다음글</span> 다음글입니다 </div>
+              <div>
+                {" "}
+                <span>
+                  {" "}
+                  <b>&lt;</b> 이전글
+                </span>{" "}
+                이전글입니다{" "}
+              </div>
+              <div>
+                {" "}
+                <span>
+                  {" "}
+                  <b>&gt;</b> 다음글
+                </span>{" "}
+                다음글입니다{" "}
+              </div>
             </nav>
           </div>
-          <div className='catalogue'>
-          <button onClick={() => { navigate('/notice')}}>목록</button>
+          <div className="catalogue">
+            <button
+              onClick={() => {
+                navigate("/notice");
+              }}
+            >
+              목록
+            </button>
           </div>
-      </div>
-}
-
-</div>
-)
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default NoticeDetailPage;

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -105,7 +105,7 @@ function NoticePage(props) {
       </div>
     ));
   }
-  const onClickDetaile = (list) => {
+  const onClickDetail = (list) => {
     call("/api/user/info", "GET").then((response) => {
       if (response !== undefined && response !== "undefined") {
         navigate("/noticeDetail", {
@@ -193,7 +193,7 @@ function NoticePage(props) {
                     <div
                       className="content"
                       onClick={() => {
-                        onClickDetaile(list);
+                        onClickDetail(list);
                       }}
                     >
                       <div className="num">{list.id}</div>


### PR DESCRIPTION
## 👀 이슈

resolve #58 

## 📌 개요

공지사항 디테일 페이지를 수정합니다.

## 👩‍💻 작업 사항

- 공지사항 디테일 페이지 제목부분에 articleId 뜨던걸 제목으로 제대로 뜨도록 수정
- 공지사항 디테일 페이지 여백 및 크기 수정
- NoticeDetaile로 되어있던 코드 NoticeDetail로 수정

## ✅ 참고 사항

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/57143818/180608324-3f8d771f-3264-4f76-9d68-695ae9f1ea4a.png">
