### PR TITLE
[feat]: (게시글 작성) 컴포넌트 내 "작성취소" 버튼 기능 활성화 (#104)

### DIFF
--- a/src/pages/exam/ExamUpdate.js
+++ b/src/pages/exam/ExamUpdate.js
@@ -115,6 +115,24 @@ function ExamUpdate() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../exam");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -163,7 +181,7 @@ function ExamUpdate() {
           <Button id="examBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="light" size="lg">
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>

--- a/src/pages/freeBoard/FreeBoardUpdate.js
+++ b/src/pages/freeBoard/FreeBoardUpdate.js
@@ -45,8 +45,8 @@ function FreeBoardUpdate() {
     e.preventDefault();
 
     const freeBoardBtn = document.getElementById("freeBoardBtn");
-    freeBoardBtn.setAttribute('disabled', true);
-    freeBoardBtn.innerText = "글등록 중..."
+    freeBoardBtn.setAttribute("disabled", true);
+    freeBoardBtn.innerText = "글등록 중...";
 
     let formData = new FormData();
 
@@ -105,10 +105,10 @@ function FreeBoardUpdate() {
           Swal.fire({
             icon: "error",
             title: "게시글 작성을 실패했습니다.",
-          }).then((result)=>{
-            if(result){
-              freeBoardBtn.removeAttribute('disabled');
-              freeBoardBtn.innerText = "작성완료"
+          }).then((result) => {
+            if (result) {
+              freeBoardBtn.removeAttribute("disabled");
+              freeBoardBtn.innerText = "작성완료";
             }
           });
         }

--- a/src/pages/freeBoard/FreeBoardUpdate.js
+++ b/src/pages/freeBoard/FreeBoardUpdate.js
@@ -115,6 +115,24 @@ function FreeBoardUpdate() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../freeBoard");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -163,7 +181,7 @@ function FreeBoardUpdate() {
           <Button id="freeBoardBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="light" size="lg">
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>

--- a/src/pages/notice/NoticeUpdate.js
+++ b/src/pages/notice/NoticeUpdate.js
@@ -12,7 +12,7 @@ function NoticeRegisteration() {
   const [authorizationValue, setAuthorizationValue] = useState("");
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
   const [uploadfile, setUploadfile] = useState([]);
-  const [notice, setNotice] = useState({ title: "", content: ""});
+  const [notice, setNotice] = useState({ title: "", content: "" });
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -44,19 +44,17 @@ function NoticeRegisteration() {
   const onSubmit = (e) => {
     e.preventDefault();
 
-
     const noticeBtn = document.getElementById("noticeBtn");
-    noticeBtn.setAttribute('disabled', true);
-    noticeBtn.innerText = "글등록 중..."
+    noticeBtn.setAttribute("disabled", true);
+    noticeBtn.innerText = "글등록 중...";
 
     let formData = new FormData();
     formData.append("file", uploadfile[0]);
 
     formData.append(
-        "article",
-        new Blob([JSON.stringify(notice)], { type: "application/json" })
+      "article",
+      new Blob([JSON.stringify(notice)], { type: "application/json" })
     );
-
 
     if (authorizationValue === "") {
       Swal.fire({
@@ -89,90 +87,96 @@ function NoticeRegisteration() {
     };
 
     axios
-        .post(API_BASE_URL + `/api/boards/${boardId}/articles`, formData, {
-          headers: headers,
-        })
-        .then((response) => {
-          if (response.data.success) {
-            Swal.fire({
-              icon: "success",
-              title: "게시글 작성을 성공했습니다.",
-            }).then((result) => {
-              if (result.isConfirmed) {
-                navigate("/notice");
-              }
-            });
-          } else {
-            Swal.fire({
-              icon: "error",
-              title: "게시글 작성을 실패했습니다.",
-            }).then((result)=>{
-              if(result){
-                noticeBtn.removeAttribute('disabled');
-                noticeBtn.innerText = "작성완료"
-              }
-            });
-          }
-        });
+      .post(API_BASE_URL + `/api/boards/${boardId}/articles`, formData, {
+        headers: headers,
+      })
+      .then((response) => {
+        if (response.data.success) {
+          Swal.fire({
+            icon: "success",
+            title: "게시글 작성을 성공했습니다.",
+          }).then((result) => {
+            if (result.isConfirmed) {
+              navigate("/notice");
+            }
+          });
+        } else {
+          Swal.fire({
+            icon: "error",
+            title: "게시글 작성을 실패했습니다.",
+          }).then((result) => {
+            if (result) {
+              noticeBtn.removeAttribute("disabled");
+              noticeBtn.innerText = "작성완료";
+            }
+          });
+        }
+      });
   };
 
   return (
-      <div className="container"
-           style={{
-             paddingLeft: "100px",
-             paddingRight: "100px",
-             marginBottom: "100px",
-           }}>
+    <div
+      className="container"
+      style={{
+        paddingLeft: "100px",
+        paddingRight: "100px",
+        marginBottom: "100px",
+      }}
+    >
+      <div>
         <div>
-          <div>
-            <Form
-                onSubmit={(e) => {
-                  onSubmit(e);
+          <Form
+            onSubmit={(e) => {
+              onSubmit(e);
+            }}
+          >
+            <Form.Group>
+              <Form.Label>제목</Form.Label>
+              <Form.Control
+                className="mb-3"
+                type="text"
+                placeholder="제목"
+                onChange={(e) => {
+                  setNotice({ ...notice, title: e.target.value });
                 }}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3" controlId="formFileMultiple">
+              <Form.Label>파일 등록</Form.Label>
+              <Form.Control
+                className="mb-3"
+                type="file"
+                onChange={(e) => {
+                  setUploadfile(e.target.files);
+                }}
+              />
+            </Form.Group>
+            <Form.Group
+              className="mb-3"
+              controlId="exampleForm.ControlTextarea1"
             >
-              <Form.Group>
-                <Form.Label>제목</Form.Label>
-                <Form.Control
-                    className="mb-3"
-                  type="text"
-                  placeholder="제목"
-                    onChange={(e) => {
-                      setNotice({ ...notice, title: e.target.value });
-                    }}
-                />
-              </Form.Group>
-                <Form.Group className="mb-3" controlId="formFileMultiple">
-                  <Form.Label>파일 등록</Form.Label>
-                  <Form.Control
-                      className="mb-3"
-                      type="file"
-                      onChange={(e) => {
-                        setUploadfile(e.target.files);
-                      }}
-                  />
-                </Form.Group>
-                <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
-                  <Form.Label>내용</Form.Label>
-                  <Form.Control
-                      as="textarea"
-                      rows={3}
-                      onChange={(e) => {
-                        setNotice({ ...notice, content: e.target.value });
-                      }}
-                  />
-
-              </Form.Group>
-              <div style={{ display: "flex", justifyContent: "center" }}>
-                <Button id="noticeBtn" variant="dark" type="submit" size="lg">글등록</Button>
-                <Button variant="light" size="lg">목록으로</Button>
-              </div>
-            </Form>
-          </div>
+              <Form.Label>내용</Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={3}
+                onChange={(e) => {
+                  setNotice({ ...notice, content: e.target.value });
+                }}
+              />
+            </Form.Group>
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <Button id="noticeBtn" variant="dark" type="submit" size="lg">
+                글등록
+              </Button>
+              <Button variant="light" size="lg">
+                목록으로
+              </Button>
+            </div>
+          </Form>
         </div>
-        <div>
-        </div>
-
       </div>
+      <div></div>
+    </div>
   );
 }
 

--- a/src/pages/notice/NoticeUpdate.js
+++ b/src/pages/notice/NoticeUpdate.js
@@ -114,6 +114,24 @@ function NoticeRegisteration() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../notice");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -166,10 +184,10 @@ function NoticeRegisteration() {
             </Form.Group>
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Button id="noticeBtn" variant="dark" type="submit" size="lg">
-                글등록
+                작성완료
               </Button>
-              <Button variant="light" size="lg">
-                목록으로
+              <Button variant="grey" size="lg" onClick={handlePostCancel}>
+                작성취소
               </Button>
             </div>
           </Form>

--- a/src/pages/report/ReportUpdate.js
+++ b/src/pages/report/ReportUpdate.js
@@ -115,6 +115,24 @@ function ReportUpdate() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../report");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -163,7 +181,7 @@ function ReportUpdate() {
           <Button id="examBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="light" size="lg">
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>

--- a/src/pages/seminar/SeminarUpdate.js
+++ b/src/pages/seminar/SeminarUpdate.js
@@ -115,6 +115,24 @@ function SeminarUpdate() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../seminar");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -163,7 +181,7 @@ function SeminarUpdate() {
           <Button id="examBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="light" size="lg">
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>

--- a/src/pages/subProject/ProjectUpdate.js
+++ b/src/pages/subProject/ProjectUpdate.js
@@ -115,6 +115,24 @@ function ProjectUpdate() {
       });
   };
 
+  const handlePostCancel = () => {
+    Swal.fire({
+      title: "글 작성을 취소하시겠습니까?",
+      text: "다시 되돌릴 수 없습니다.",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        navigate("../project");
+      } else {
+      }
+    });
+  };
+
   return (
     <div
       className="container"
@@ -163,7 +181,7 @@ function ProjectUpdate() {
           <Button id="examBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="light" size="lg">
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>


### PR DESCRIPTION
## 👀 이슈

resolve #104 

## 📌 개요

사진첩 이외의 컴포넌트들에서 게시글 작성 시 **`작성취소`** 버튼을
클릭하였을 때 아무런 동작이 없었던 부분에 대하여 알맞은 기능을
추가하게 되었습니다.

## 👩‍💻 작업 사항

- **`작성취소`** 버튼 클릭 시 게시글의 작성 취소 여부를 확인하도록
코드를 추가하였습니다.

## ✅ 참고 사항
- 게시글 작성 컴포넌트(공지사항, 자료실 내 게시판들, 자유게시판) 내용 수정이 이뤄지고 난 이후의 페이지

![after](https://user-images.githubusercontent.com/56868605/187632594-e18caad6-a28a-40ed-8914-f2b093092149.gif)

- 기존 공지사항 게시글 작성 컴포넌트 내에 있는 버튼 텍스트의 문구를
다른 게시판과 동일하게 수정하였습니다.

![스크린샷 2022-08-31 오후 5 30 06](https://user-images.githubusercontent.com/56868605/187633169-494fda55-9ff1-4245-9432-65290c62f7da.png)