### PR TITLE
[fix]: 사진첩 (게시글 작성) 컴포넌트 내 Warning(경고) 제거 (#106)

### DIFF
--- a/src/pages/photo/PhotoUpdate.js
+++ b/src/pages/photo/PhotoUpdate.js
@@ -258,10 +258,10 @@ function PhotoUpdate() {
           />
         </Form.Group>
         <div style={{ display: "flex", justifyContent: "center" }}>
-          <Button id="photoBtn" variant="dark" type="submit" size="lg" abled>
+          <Button id="photoBtn" variant="dark" type="submit" size="lg">
             작성완료
           </Button>
-          <Button variant="grey" size="lg" abled onClick={handlePostCancel}>
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
             작성취소
           </Button>
         </div>


### PR DESCRIPTION
## 👀 이슈

resolve #106 

## 📌 개요

기존 **`PhotoUpdate.js`** 파일 내 글 작성과 관련된 버튼의 속성에서
`abled` 속성을 String값으로 입력해야 하는데, 일반적인 true(Default value)값이
입력되어 경고가 발생하였습니다.

## 👩‍💻 작업 사항

- `게시글 작성` 혹은 `게시글 취소` 와 관련된 기능에서는 글 작성을 할 때를 제외하고
`abled` 속성이 불필요하기 때문에 해당 속성을 제거하여 경고를 제거하였습니다.

## ✅ 참고 사항