### PR TITLE
[fix]: 게시글 디테일 컴포넌트 내 첨부파일 요소 디자인 수정 (#108)

### DIFF
--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -69,19 +69,11 @@ function ExamDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -118,19 +110,11 @@ function ExamDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>

--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -42,23 +42,29 @@ function ExamDetailPage() {
           </div>
 
           <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
               </div>
-              :
-              <div>
-              </div>
-          }
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -43,24 +43,30 @@ function FreeBoardDetailPage() {
             </div>
           </div>
           <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath}
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
+              </div>
+            </div>
+          ) : (
+            <div></div>
+          )}
 
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
-          
           <div>
             <nav>
               <div>

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -71,19 +71,11 @@ function FreeBoardDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -120,19 +112,11 @@ function FreeBoardDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -44,23 +44,29 @@ function NoticeDetailPage() {
           </div>
 
           <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
               </div>
-              :
-              <div>
-              </div>
-          }
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -71,19 +71,11 @@ function NoticeDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -120,19 +112,11 @@ function NoticeDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -44,23 +44,29 @@ function ReportDetailPage() {
           </div>
 
           <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
               </div>
-              :
-              <div>
-              </div>
-          }
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -71,19 +71,11 @@ function ReportDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -120,19 +112,11 @@ function ReportDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -46,21 +46,23 @@ function SeminarDetailPage() {
           <div className="contents">{article.content}</div>
           {article.files.length !== 0 ? (
             <div className="file-download-frame">
-              파일 다운로드
-              <br />
-              <a
-                href={
-                  "http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath
-                }
-                className="text-decoration-none"
-              >
-                {article.files[0].fileName}
-              </a>
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
+              </div>
             </div>
           ) : (
             <div></div>

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -71,19 +71,11 @@ function SeminarDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -120,19 +112,11 @@ function SeminarDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -42,23 +42,29 @@ function ProjectDetailPage() {
           </div>
 
           <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
-                  location.state.boardId +
-                  "/articles/" +
-                  location.state.articleId +
-                  "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              <div className="border-top p-3">
+                <h5 className="mb-3">첨부파일</h5>
+                <a
+                  href={
+                    "http://localhost:8080/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    article.files[0].filePath
+                  }
+                  className="text-decoration-none border-0 p-2"
+                >
+                  <span className="icon fa-file"></span>{" "}
+                  {article.files[0].fileName}
+                </a>
               </div>
-              :
-              <div>
-              </div>
-          }
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -69,19 +69,11 @@ function ProjectDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>
@@ -118,19 +110,11 @@ function ProjectDetailPage() {
             <nav>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&lt;</b> 이전글
-                </span>{" "}
-                이전글입니다{" "}
+                <span>이전글</span> 이전글입니다{" "}
               </div>
               <div>
                 {" "}
-                <span>
-                  {" "}
-                  <b>&gt;</b> 다음글
-                </span>{" "}
-                다음글입니다{" "}
+                <span>다음글</span> 다음글입니다{" "}
               </div>
             </nav>
           </div>


### PR DESCRIPTION
## 👀 이슈

resolve #108 

## 📌 개요

게시글 내 첨부파일 요소의 디자인을 일부 수정하였습니다.

## 👩‍💻 작업 사항

각 게시글 디테일 컴포넌트 파일을 수정하여 디자인을
변경하였습니다.

## ✅ 참고 사항
- 변경 후 `첨부파일` 요소의 디자인

![after](https://user-images.githubusercontent.com/56868605/188259151-fa5f7f50-dce4-4781-8bf7-1d52af6e9437.png)

- `이전글 & 다음글` 내 특수문자(<, >)를 제거

<img width="247" alt="스크린샷 2022-09-03 오후 4 43 39" src="https://user-images.githubusercontent.com/56868605/188261299-f3a2f514-462d-4670-90db-09dcca65927c.png">