### PR TITLE
[feat]: 게시글 디테일 컴포넌트 내 "좋아요" 요소 추가 (#110)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,30 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <base href="/">
+    <base href="/" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
-    name="description"
-    content="Web site created using create-react-app"
+      name="description"
+      content="Web site created using create-react-app"
     />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx"
+      crossorigin="anonymous"
+    />
     <!--v4.6.x-->
     <link rel="icon" href="%PUBLIC_URL%/favicon_rec.png" />
     <link
-            rel="stylesheet"
-            href="https://unpkg.com/swiper@8/swiper-bundle.min.css"
+      rel="stylesheet"
+      href="https://unpkg.com/swiper@8/swiper-bundle.min.css"
     />
-    <link rel="stylesheet" href="./assets/css/main.css"  />
+    <link rel="stylesheet" href="./assets/css/main.css" />
     <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="assets/js/jquery.min.js"></script>
     <script src="assets/js/jquery.dropotron.min.js"></script>
     <script src="assets/js/browser.min.js"></script>
     <script src="assets/js/breakpoints.min.js"></script>
     <script src="assets/js/util.js"></script>
     <script src="assets/js/main.js"></script>
+    <script
+      src="https://kit.fontawesome.com/ab714675d3.js"
+      crossorigin="anonymous"
+    ></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/pages/exam/ExamDetail.scss
+++ b/src/pages/exam/ExamDetail.scss
@@ -1,0 +1,91 @@
+.ExamDetail {
+  button {
+    padding: 0;
+  }
+  .container {
+    display: flex;
+    flex-direction: column;
+
+    width: 80%;
+    margin-top: 150px;
+
+    > div {
+      padding-left: 1%;
+      padding-right: 1%;
+    }
+  }
+
+  .pageTitle {
+    border-top: 2px solid #000;
+    border-bottom: 1px solid #dfdfdf;
+    padding: 17.5px 0 16px;
+  }
+
+  .pageInfo dt,
+  dd {
+    float: left;
+    margin-right: 15px;
+    display: inline;
+  }
+
+  .contents {
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
+  }
+
+  nav {
+    border-bottom: 1px solid #dfdfdf;
+    margin-bottom: 1.5%;
+    div {
+      border-top: 1px solid #dfdfdf;
+      cursor: pointer;
+
+      span {
+        display: inline-block;
+        width: 10%;
+        height: 45px;
+        line-height: 45px;
+        font-size: 17px;
+        text-align: center;
+        background-color: #f7f8f9;
+        border-right: 1px solid #dfdfdf;
+        margin-right: 1.5%;
+        cursor: auto;
+      }
+    }
+  }
+
+  .catalogue {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 3%;
+    button {
+      margin-right: 1%;
+      width: 8%;
+      height: 2.5em;
+    }
+  }
+}

--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -50,9 +50,9 @@ function ExamDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -7,6 +7,7 @@ function ExamDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -22,7 +23,7 @@ function ExamDetailPage() {
   }, [location.state.boardId, location.state.articleId]);
 
   return (
-    <div className="FreeBoardDetail">
+    <div className="ExamDetail">
       {loading ? (
         <div className="container">
           <div className="pageTitle">
@@ -41,24 +42,50 @@ function ExamDetailPage() {
             </div>
           </div>
 
-          <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              파일 다운로드
+              <br />
+              <a
+                href={
+                  "http://localhost:8080/no-permit/api/boards/" +
                   location.state.boardId +
                   "/articles/" +
                   location.state.articleId +
                   "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
+                  article.files[0].filePath
+                }
+                className="text-decoration-none"
+              >
+                {article.files[0].fileName}
+              </a>
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/freeBoard/FreeBoardDetail.scss
+++ b/src/pages/freeBoard/FreeBoardDetail.scss
@@ -1,5 +1,5 @@
 .FreeBoardDetail {
-  button{
+  button {
     padding: 0;
   }
   .container {
@@ -29,7 +29,31 @@
   }
 
   .contents {
-    padding: 5% 0px 5% 0px;
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
   }
 
   nav {

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -9,6 +9,7 @@ function FreeBoardDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -42,25 +43,51 @@ function FreeBoardDetailPage() {
               </dl>
             </div>
           </div>
-          <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              파일 다운로드
+              <br />
+              <a
+                href={
+                  "http://localhost:8080/no-permit/api/boards/" +
                   location.state.boardId +
                   "/articles/" +
                   location.state.articleId +
                   "/files/" +
-                  article.files[0].filePath}
+                  article.files[0].filePath
+                }
+                className="text-decoration-none"
+              >
+                {article.files[0].fileName}
+              </a>
+            </div>
+          ) : (
+            <div></div>
+          )}
 
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
-          
           <div>
             <nav>
               <div>

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -51,9 +51,9 @@ function FreeBoardDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/notice/NoticeDetail.scss
+++ b/src/pages/notice/NoticeDetail.scss
@@ -1,5 +1,5 @@
 .NoticeDetail {
-  button{
+  button {
     padding: 0;
   }
   .container {
@@ -27,7 +27,31 @@
   }
 
   .contents {
-    padding: 5% 0px 5% 0px;
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
   }
 
   nav {

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -9,6 +9,7 @@ function NoticeDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -43,24 +44,50 @@ function NoticeDetailPage() {
             </div>
           </div>
 
-          <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              파일 다운로드
+              <br />
+              <a
+                href={
+                  "http://localhost:8080/no-permit/api/boards/" +
                   location.state.boardId +
                   "/articles/" +
                   location.state.articleId +
                   "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
+                  article.files[0].filePath
+                }
+                className="text-decoration-none"
+              >
+                {article.files[0].fileName}
+              </a>
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -52,9 +52,9 @@ function NoticeDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/report/ReportDetail.scss
+++ b/src/pages/report/ReportDetail.scss
@@ -1,5 +1,5 @@
 .ReportDetail {
-  button{
+  button {
     padding: 0;
   }
   .container {
@@ -29,7 +29,31 @@
   }
 
   .contents {
-    padding: 5% 0px 5% 0px;
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
   }
 
   nav {

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -9,6 +9,7 @@ function ReportDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -43,24 +44,50 @@ function ReportDetailPage() {
             </div>
           </div>
 
-          <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              파일 다운로드
+              <br />
+              <a
+                href={
+                  "http://localhost:8080/no-permit/api/boards/" +
                   location.state.boardId +
                   "/articles/" +
                   location.state.articleId +
                   "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
+                  article.files[0].filePath
+                }
+                className="text-decoration-none"
+              >
+                {article.files[0].fileName}
+              </a>
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -52,9 +52,9 @@ function ReportDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/seminar/SeminarDetail.scss
+++ b/src/pages/seminar/SeminarDetail.scss
@@ -29,7 +29,31 @@
   }
 
   .contents {
-    padding: 5% 0px 5% 0px;
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
   }
 
   nav {

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -52,9 +52,9 @@ function SeminarDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -9,6 +9,7 @@ function SeminarDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -43,7 +44,29 @@ function SeminarDetailPage() {
             </div>
           </div>
 
-          <div className="contents">{article.content}</div>
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
           {article.files.length !== 0 ? (
             <div className="file-download-frame">
               파일 다운로드

--- a/src/pages/subProject/ProjectDetail.scss
+++ b/src/pages/subProject/ProjectDetail.scss
@@ -1,0 +1,91 @@
+.ProjectDetail {
+  button {
+    padding: 0;
+  }
+  .container {
+    display: flex;
+    flex-direction: column;
+
+    width: 80%;
+    margin-top: 150px;
+
+    > div {
+      padding-left: 1%;
+      padding-right: 1%;
+    }
+  }
+
+  .pageTitle {
+    border-top: 2px solid #000;
+    border-bottom: 1px solid #dfdfdf;
+    padding: 17.5px 0 16px;
+  }
+
+  .pageInfo dt,
+  dd {
+    float: left;
+    margin-right: 15px;
+    display: inline;
+  }
+
+  .contents {
+    padding: 5% 0px 1% 0px;
+    .contentsBottom {
+      margin: 8% auto 1%;
+      text-align: center;
+      .like {
+        border-radius: 10px;
+        padding: 1.7% 1.25% 1.25%;
+        background-color: rgb(13, 110, 253);
+        cursor: pointer;
+        i {
+          font-size: 30px;
+        }
+        .likeCnt {
+          padding-left: 7px;
+          -ms-user-select: none;
+          -moz-user-select: -moz-none;
+          -khtml-user-select: none;
+          -webkit-user-select: none;
+          user-select: none;
+        }
+      }
+      .like:hover {
+        background-color: rgb(8, 90, 214);
+      }
+    }
+  }
+
+  nav {
+    border-bottom: 1px solid #dfdfdf;
+    margin-bottom: 1.5%;
+    div {
+      border-top: 1px solid #dfdfdf;
+      cursor: pointer;
+
+      span {
+        display: inline-block;
+        width: 10%;
+        height: 45px;
+        line-height: 45px;
+        font-size: 17px;
+        text-align: center;
+        background-color: #f7f8f9;
+        border-right: 1px solid #dfdfdf;
+        margin-right: 1.5%;
+        cursor: auto;
+      }
+    }
+  }
+
+  .catalogue {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 3%;
+    button {
+      margin-right: 1%;
+      width: 8%;
+      height: 2.5em;
+    }
+  }
+}

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -50,9 +50,9 @@ function ProjectDetailPage() {
                 onClick={() => setLike((prev) => !prev)}
               >
                 {like ? (
-                  <i class="fa-solid fa-thumbs-up"></i>
+                  <i className="fa-solid fa-thumbs-up"></i>
                 ) : (
-                  <i class="fa-regular fa-thumbs-up"></i>
+                  <i className="fa-regular fa-thumbs-up"></i>
                 )}
                 {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -7,6 +7,7 @@ function ProjectDetailPage() {
   const location = useLocation();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
+  const [like, setLike] = useState(false);
 
   useEffect(() => {
     call(
@@ -41,24 +42,50 @@ function ProjectDetailPage() {
             </div>
           </div>
 
-          <div className="contents">{article.content}</div>
-          {
-            article.files.length !== 0 ?
-              <div className="file-download-frame">
-                파일 다운로드<br />
-                <a href={"http://localhost:8080/no-permit/api/boards/" +
+          <div className="contents">
+            {article.content}
+            <div className="contentsBottom">
+              <span
+                className="text-center text-white like"
+                onClick={() => setLike((prev) => !prev)}
+              >
+                {like ? (
+                  <i class="fa-solid fa-thumbs-up"></i>
+                ) : (
+                  <i class="fa-regular fa-thumbs-up"></i>
+                )}
+                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
+                {like ? (
+                  <span className="likeCnt font-weight-bold">
+                    {article.likeCnt + 1}
+                  </span>
+                ) : (
+                  <span className="likeCnt">{article.likeCnt}</span>
+                )}
+              </span>
+            </div>
+          </div>
+          {article.files.length !== 0 ? (
+            <div className="file-download-frame">
+              파일 다운로드
+              <br />
+              <a
+                href={
+                  "http://localhost:8080/no-permit/api/boards/" +
                   location.state.boardId +
                   "/articles/" +
                   location.state.articleId +
                   "/files/" +
-                  article.files[0].filePath}
-
-                className="text-decoration-none">{article.files[0].fileName}</a>
-              </div>
-              :
-              <div>
-              </div>
-          }
+                  article.files[0].filePath
+                }
+                className="text-decoration-none"
+              >
+                {article.files[0].fileName}
+              </a>
+            </div>
+          ) : (
+            <div></div>
+          )}
           <div>
             <nav>
               <div>


### PR DESCRIPTION
## 👀 이슈

resolve #110 

## 📌 개요

게시글 내용 하단에 **`좋아요`** 기능을 수행할 수 있는 UI 요소가 필요하였습니다.

## 👩‍💻 작업 사항

- 각 게시글 디테일 컴포넌트 파일에 **`좋아요`** 요소를 추가하고자 하였습니다.
> (요소만 추가하였기 때문에 변경된 좋아요 수에 따른 값은 DB에 추가되지 않고, 게시글 조회수와 좋아요 수가 동일하게 넘어오는 문제가 있는 것 같습니다)

## ✅ 참고 사항
- 추가 후 컴포넌트 화면

![after](https://user-images.githubusercontent.com/56868605/188262585-b3298bcd-1694-4a39-a958-2367cde8a4da.gif)