### PR TITLE
[feat]: 게시판 전체 Pagination 기능 추가 (#114)

### DIFF
--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -12,6 +12,8 @@ function ExamPage() {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -43,49 +45,22 @@ function ExamPage() {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const examUpload = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./examUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
         });
-      }
-    })
-  };
-
-  const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("/examDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -96,6 +71,74 @@ function ExamPage() {
         });
       }
     });
+  };
+
+  const onClickDetail = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/examDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/login");
+          }
+        });
+      }
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
   };
 
   return (
@@ -161,7 +204,7 @@ function ExamPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">
@@ -187,21 +230,11 @@ function ExamPage() {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -102,6 +102,7 @@ function FreeBoardPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -12,6 +12,8 @@ function FreeBoardPage() {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -20,7 +22,7 @@ function FreeBoardPage() {
           if (response.response[i].name === "자유게시판") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}`,
               "GET"
             ).then((response) => {
               // console.log(response);
@@ -43,20 +45,22 @@ function FreeBoardPage() {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const freeBoardUpload = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./freeBoardUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else{
+        });
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -66,12 +70,11 @@ function FreeBoardPage() {
           }
         });
       }
-    })
-    
+    });
   };
 
   const onClickDetail = (list) => {
-    myRole().then((response)=>{
+    myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("/freeBoardDetail", {
           state: {
@@ -79,14 +82,12 @@ function FreeBoardPage() {
             articleId: list.id,
           },
         });
-      } 
-      else if (response ==="temp"){
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+        });
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -96,13 +97,57 @@ function FreeBoardPage() {
           }
         });
       }
-    })
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
   };
 
   return (
     <div className="noticePage">
       <div className="container">
-        <img src={free} alt="자유게시판 배너" style={{ width: "100%", height: "200px" }}></img>
+        <img
+          src={free}
+          alt="자유게시판 배너"
+          style={{ width: "100%", height: "200px" }}
+        ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>
           <span>{"/"}</span>
@@ -156,7 +201,7 @@ function FreeBoardPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">
@@ -182,21 +227,11 @@ function FreeBoardPage() {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -104,6 +104,7 @@ function NoticePage(props) {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -1,5 +1,5 @@
 import "./NoticePage.scss";
-import {Pagination } from "react-bootstrap";
+import { Pagination } from "react-bootstrap";
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
@@ -15,6 +15,8 @@ function NoticePage(props) {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -45,49 +47,22 @@ function NoticePage(props) {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const onClickRegister = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("/notice/noticeUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
         });
-      }
-    })
-  };
-
-  const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("/noticeDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -100,10 +75,81 @@ function NoticePage(props) {
     });
   };
 
+  const onClickDetail = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/noticeDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/login");
+          }
+        });
+      }
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
+  };
+
   return (
     <div className="noticePage">
       <div className="container">
-        <img src={notice} alt="공지사항 배너" style={{ width: "100%", height: "200px" }}></img>
+        <img
+          src={notice}
+          alt="공지사항 배너"
+          style={{ width: "100%", height: "200px" }}
+        ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>
           <span>{"/"}</span>
@@ -159,7 +205,7 @@ function NoticePage(props) {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">
@@ -185,21 +231,11 @@ function NoticePage(props) {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>

--- a/src/pages/notice/NoticePage.scss
+++ b/src/pages/notice/NoticePage.scss
@@ -131,5 +131,8 @@
   .pageNum {
     display: flex;
     justify-content: center;
+    .pagination > li:first-child {
+      margin-top: 13.5px;
+    }
   }
 }

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -12,6 +12,8 @@ function ReportPage() {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -43,49 +45,22 @@ function ReportPage() {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const reportUpload = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./reportUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else{
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
         });
-      }
-    })
-  };
-
-  const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("/reportDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -96,6 +71,74 @@ function ReportPage() {
         });
       }
     });
+  };
+
+  const onClickDetail = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/reportDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/login");
+          }
+        });
+      }
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
   };
 
   return (
@@ -187,21 +230,11 @@ function ReportPage() {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -12,6 +12,8 @@ function SeminarPage() {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -43,49 +45,22 @@ function SeminarPage() {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const seminarUpload = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./seminarUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else{
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
         });
-      }
-    })
-  };
-
-  const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("/seminarDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -96,6 +71,74 @@ function SeminarPage() {
         });
       }
     });
+  };
+
+  const onClickDetail = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/seminarDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/login");
+          }
+        });
+      }
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
   };
 
   return (
@@ -187,21 +230,11 @@ function SeminarPage() {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -12,6 +12,8 @@ function ProjectPage() {
   const [boardlist, setBoardlist] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardId] = useState();
+  const [pageNum, setPageNum] = useState(1);
+  const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -43,49 +45,22 @@ function ProjectPage() {
         });
       }
     });
-  }, []);
+
+    if (pageNum % 10 === 1) setPageList(pageNum);
+    else if (pageNum % 10 === 0) setPageList(pageNum - 9);
+    else setPageList(parseInt(pageNum / 10) * 10 + 1);
+  }, [pageNum]);
 
   const examUpload = () => {
     myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./projectUpdate");
-      }
-      else if (response === "temp") {
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else{
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
         });
-      }
-    })
-  };
-
-  const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("/projectDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -96,6 +71,74 @@ function ProjectPage() {
         });
       }
     });
+  };
+
+  const onClickDetail = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/projectDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/login");
+          }
+        });
+      }
+    });
+  };
+
+  /** Pagination 버튼을 생성하는 함수 */
+  const addingPaginationItem = () => {
+    if (!Object.keys(boardlist).length) return;
+    const result = [];
+    for (let k = 0; k < 10; k++) {
+      result.push(
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
+      );
+      if (pageList + k === boardlist.totalPages) break;
+    }
+    return result;
+  };
+
+  /**
+   * Pagination 각 기능 버튼들의 동작사항을 정의하는 함수
+   * @param {string} command 명령 문자열을 넣어주세요
+   * */
+  const onChangingPage = (command) => {
+    switch (command) {
+      case "first":
+        setPageNum(1);
+        break;
+      case "prev":
+        if (boardlist.first) return;
+        setPageNum((prev) => prev - 1);
+        break;
+      case "next":
+        if (boardlist.last) return;
+        setPageNum((prev) => prev + 1);
+        break;
+      default:
+        setPageNum(boardlist.totalPages);
+    }
   };
 
   return (
@@ -187,21 +230,11 @@ function ProjectPage() {
 
       <div className="pageNum">
         <Pagination>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item active>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
         </Pagination>
       </div>
     </div>


### PR DESCRIPTION
## 👀 이슈

resolve #114 

## 📌 개요

기존 홈페이지 내 존재하는 게시판에 Pagination 기능이
필요하여 추가하였습니다.

## 👩‍💻 작업 사항

- 각 게시글 페이지마다 15개의 글을 보여주며 DB 내에 그 이상의
글이 작성되어 있다면, 다음 게시글 페이지 버튼이 생성되어 그 외의
글들을 확인할 수 있습니다. 한 화면에 최대 10개의 게시글 페이지
수가 고정되어 있어 11페이지 이상의 생성이 이뤄지면 다음으로
11~20페이지가 나타나는 방식으로 제작하였습니다.

## ✅ 참고 사항

- 변경 후 페이지 사진 (GIF 파일이 첨부되어 있습니다)

![after](https://user-images.githubusercontent.com/56868605/188434387-cb709447-60fb-4eeb-af8d-ec62036d93bd.gif)