### PR TITLE
[fix]: Pagination 기능에 대한 잘못된 API 호출문 수정 (#122)

### DIFF
--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -22,7 +22,7 @@ function ExamPage() {
           if (response.response[i].name === "족보") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               // console.log(response);

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -22,7 +22,7 @@ function FreeBoardPage() {
           if (response.response[i].name === "자유게시판") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               // console.log(response);

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -25,7 +25,7 @@ function NoticePage(props) {
           if (response.response[i].name === "공지사항") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               if (response.success) {

--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -21,7 +21,7 @@ const PhotoList = () => {
           if (response.response[i].name === "사진첩") {
             setBoardid(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/1?pageSize=16`,
               "GET"
             ).then((response) => {
               if (response.success) {
@@ -46,7 +46,7 @@ const PhotoList = () => {
   }, []);
 
   const onClickDetail = (list) => {
-    myRole().then((response)=>{
+    myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./photoDetail", {
           state: {
@@ -54,14 +54,12 @@ const PhotoList = () => {
             articleId: list.id,
           },
         });
-      } 
-      else if (response ==="temp"){
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+        });
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -70,7 +68,6 @@ const PhotoList = () => {
             navigate("/login");
           }
         });
-
       }
     });
   };

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -22,7 +22,7 @@ function ReportPage() {
           if (response.response[i].name === "활동보고서") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               // console.log(response);

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -22,7 +22,7 @@ function SeminarPage() {
           if (response.response[i].name === "특강자료") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               // console.log(response);

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -22,7 +22,7 @@ function ProjectPage() {
           if (response.response[i].name === "소규모프로젝트") {
             setBoardId(response.response[i].id);
             call(
-              `/no-permit/api/boards/${response.response[i].id}/pages/1`,
+              `/no-permit/api/boards/${response.response[i].id}/pages/${pageNum}?pageSize=10`,
               "GET"
             ).then((response) => {
               // console.log(response);


### PR DESCRIPTION
## 👀 이슈

resolve #122 

## 📌 개요

기존 Paignation 기능을 수행하기 위하여 사용되던 API 호출문과
요청받는 API값에 차이가 발생하여 정상적으로 데이터를 제공받지
못 하는 문제가 있었습니다.

## 👩‍💻 작업 사항

- 각 게시글에서 사용되는 API 호출문을 알맞게 수정하였습니다.
- 기존 15개의 게시글 당 하나의 페이지로 구성되었던 부분을
가시성을 보다 높이고자 한 페이지당 10개의 게시글이 조회되도록
API 호출문 쿼리를 일부 추가하였습니다.

## ✅ 참고 사항
- 수정 후 페이지 화면(정상적으로 데이터를 받음)
<img width="1004" alt="스크린샷 2022-09-18 오후 2 30 08" src="https://user-images.githubusercontent.com/56868605/190887219-055e95b5-cabd-4e62-bddd-3ac22abc690b.png">