### PR TITLE
[fix]: 홈페이지 내 위치한 비대칭 요소에 대한 디자인 일괄 조정 및 일부 요소 디자인 수정 (#126)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,9 +1,9 @@
-*{
-    margin: 0;
-    padding: 0;
+* {
+  margin: 0;
+  padding: 0;
 }
 
 .App {
-
-    margin: 0 auto;
+  font-size: 17px;
+  margin: 0 auto;
 }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -28,26 +28,33 @@ function Navigation() {
   return (
     <div className="Navigation container" style={{ marginBottom: "100px" }}>
       <div className="userStatus" style={{ display: "flex" }}>
-        <p className="attendance">접속자(0명)</p>
+        <p className="attendance">접속자 ?</p>
 
         {userInfo != null && loading ? (
           <div style={{ marginLeft: "auto" }}>
             <p className="userInfo">
               {userInfo.response.role === "ROLE_ADMIN" ? (
                 <span>
-                  <a href="/management">관리자 페이지</a> |{" "}
+                  <a href="/management" className="management">
+                    관리자 페이지
+                  </a>
                 </span>
               ) : null}
-              <a href="/checkPw">정보 수정</a> |{" "}
+              <a href="/checkPw" className="changeInfo">
+                정보 수정
+              </a>
               <a
                 href="/"
                 onClick={() => {
                   signout();
                 }}
+                className="signOut"
               >
                 로그아웃
-              </a>{" "}
-              | <a href="/">{userInfo.response.username}</a>
+              </a>
+              <a href="/" className="userName">
+                {userInfo.response.username}
+              </a>
             </p>
           </div>
         ) : (
@@ -66,7 +73,7 @@ function Navigation() {
           style={{ cursor: "pointer" }}
           onClick={() => navigate("/")}
         />
-        <ul>
+        <ul className="mt-3">
           <li>
             <a href="/clubIntro" className="icon fa-chart-bar">
               <span>샘마루</span>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -26,7 +26,10 @@ function Navigation() {
   }, [location, accessToken]);
 
   return (
-    <div className="Navigation container" style={{ marginBottom: "100px" }}>
+    <div
+      className="Navigation container"
+      style={{ marginBottom: "100px", position: "relative" }}
+    >
       <div className="userStatus" style={{ display: "flex" }}>
         <p className="attendance">접속자 ?</p>
 

--- a/src/components/Navigation.scss
+++ b/src/components/Navigation.scss
@@ -16,6 +16,26 @@
     }
     .userInfo {
       float: right;
+      a {
+        border: none;
+        // 각 유저 정보 우측에 경계선을 추가
+        &::after {
+          position: relative;
+          bottom: 3px;
+          font-size: 1px;
+          color: lightgrey;
+          padding-left: 6px;
+          content: "|";
+          padding-right: 6px;
+        }
+      }
+      // 유저명이 최 우측 요소이기 때문에 경계선을 배치하면 안 되기 때문에 content를 비움
+      .userName::after {
+        content: "";
+      }
+      a:hover {
+        text-decoration: none;
+      }
     }
 
     .user:hover {

--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -158,8 +158,8 @@ function ExamPage() {
           <span> 족보 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목

--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -147,7 +147,8 @@ function ExamPage() {
         <img
           src={exam}
           alt="족보 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -147,7 +147,8 @@ function FreeBoardPage() {
         <img
           src={free}
           alt="자유게시판 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -156,8 +156,8 @@ function FreeBoardPage() {
           <span> 자유게시판 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목

--- a/src/pages/main/MainPage.js
+++ b/src/pages/main/MainPage.js
@@ -40,6 +40,7 @@ function MainPage() {
                   height: "100%",
                   paddingbottom: "50px",
                   marginTop: "-80px",
+                  borderRadius: "50px",
                 }}
               />
               <h1 id="logo">

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -149,7 +149,8 @@ function NoticePage(props) {
         <img
           src={notice}
           alt="공지사항 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -158,8 +158,8 @@ function NoticePage(props) {
           <span> 공지사항 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목

--- a/src/pages/notice/NoticePage.scss
+++ b/src/pages/notice/NoticePage.scss
@@ -42,9 +42,11 @@
   .search {
     display: flex;
     flex-direction: row;
+    justify-content: center;
     padding: 2% 2% 2% 2%;
     background-color: #f5f5f5;
     margin-bottom: 5%;
+    text-align: center;
     .inp_sch {
       width: 90%;
     }
@@ -57,16 +59,17 @@
     }
     b {
       font-weight: bold;
-      margin-right: 1%;
+      margin-top: 2px;
     }
 
     input[type="text"] {
-      width: 75%;
+      width: 60%;
       background-color: #fff;
+      height: 36px;
     }
     input[type="submit"] {
       width: 10%;
-      height: 38px;
+      padding: 8px;
       background-color: #464545;
       color: white;
     }

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -158,8 +158,8 @@ function ReportPage() {
           <span> 활동 보고서 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -147,7 +147,8 @@ function ReportPage() {
         <img
           src={report}
           alt="활동보고서 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -147,7 +147,8 @@ function SeminarPage() {
         <img
           src={seminar}
           alt="세미나 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -158,8 +158,8 @@ function SeminarPage() {
           <span> 특강 자료 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -147,7 +147,8 @@ function ProjectPage() {
         <img
           src={project}
           alt="소규모프로젝트 배너"
-          style={{ width: "100%", height: "200px" }}
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
         ></img>
         <div className="location">
           <img className="home" src="home.png" alt="home"></img>

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -158,8 +158,8 @@ function ProjectPage() {
           <span> 소규모 프로젝트 </span>
         </div>
         <div className="search">
-          <b> 검색구분 </b>
           <div className="inp_sch">
+            <b> 검색구분 </b>
             <select name="srchTp">
               <option value="title" style={{ textAlign: "center" }}>
                 제목


### PR DESCRIPTION
## 👀 이슈

resolve #126 

## 📌 개요

홈페이지 내 배치된 요소들 중 텍스트의 대칭(수직, 수평)이 맞지 않거나,
가시성을 높일 수 있도록 일부 요소들의 디자인을 수정하고자 하였습니다.

## 👩‍💻 작업 사항

- `유저 정보` 란의 디자인 수정
- `sweetalert2` 사용 시 Navigation 요소가 좌우로 일부 이동하는 문제 해결
- 게시글 컴포넌트 내의 검색 란 내부 요소들의 수직 위치 조정 및 중앙 정렬
- 홈페이지 내에서 사용되는 폰트의 크기를 기존 보다 조금 더 작게 수정

## ✅ 참고 사항

- `유저 정보` 란의 디자인 수정 **전**

![스크린샷 2022-09-18 오후 7 04 47](https://user-images.githubusercontent.com/56868605/190901593-89210fa4-50ae-4ede-afe9-5ec277434458.png)
- `유저 정보` 란의 디자인 수정 **후**

![스크린샷 2022-09-18 오후 9 03 57](https://user-images.githubusercontent.com/56868605/190901601-edb86286-1771-4782-bad2-01ee695e064e.png)

---

- `sweetalert2` 사용 시 Navigation 요소가 좌우로 일부 이동하는 문제 해결 **전**

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/56868605/190901701-549bf9d0-ac93-49fe-b342-e04e140548a2.gif)
- `sweetalert2` 사용 시 Navigation 요소가 좌우로 일부 이동하는 문제 해결 **후**

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/56868605/190903234-a1ecbacc-825e-42ab-aba6-6a4ab6dbe367.gif)

---

- 모든 게시판 내 위치한 배너 이미지의 크기 비율 유지 적용 **전**

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/56868605/190904653-f426b97c-c11c-4f15-a7c0-8f2af4977a22.gif)

- 모든 게시판 내 위치한 배너 이미지의 크기 비율 유지 적용 **후**

![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/56868605/190903539-f3e9cb00-59b2-4882-b055-360f07cb0a83.gif)

---

- 게시글 컴포넌트 내 수직 위치 조정 및 요소들 중앙 정렬 **전**

![스크린샷 2022-09-18 오후 9 10 20](https://user-images.githubusercontent.com/56868605/190904544-10227cdc-9460-4465-ac6d-cbd9788443f3.png)

- 게시글 컴포넌트 내 수직 위치 조정 및 요소들 중앙 정렬 **후**

<img width="1107" alt="스크린샷 2022-09-18 오후 10 53 07" src="https://user-images.githubusercontent.com/56868605/190910258-c334a904-4300-4b90-88e3-efa74446bafb.png">
