### PR TITLE
[bug]: Pagination 버그 수정 (#129)

### DIFF
--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -102,7 +102,7 @@ function ExamPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -102,7 +102,7 @@ function FreeBoardPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -104,7 +104,7 @@ function NoticePage(props) {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -102,7 +102,7 @@ function ReportPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -102,7 +102,7 @@ function SeminarPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -102,7 +102,7 @@ function ProjectPage() {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(boardlist).length) return;
+    if (!boardlist.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(


### PR DESCRIPTION
## 👀 이슈

resolve #129 

## 📌 개요

게시판 내에 게시글이 하나도 등록되어 있지 않을 때 페이지 넘버가
나타나지 않도록 설계했던 부분이 잘못되어 페이지 넘버가 의도와는
다르게 표시되는 버그가 발견되어 수정하였습니다.

## 👩‍💻 작업 사항

- 각 게시판 페이지 컴포넌트 내 글 수를 확인하는 코드를 알맞게 수정

## ✅ 참고 사항
- 해결 **전**

<img width="657" alt="before" src="https://user-images.githubusercontent.com/56868605/190936377-417083b8-cc8b-4f3c-973e-23f4c92f97e8.png">

- 해결 **후**

<img width="662" alt="after" src="https://user-images.githubusercontent.com/56868605/190936332-8e8e904a-2157-4b4c-ab71-84acc6efef58.png">