### PR TITLE
[fix]: Navigation 컴포넌트 내 refreshToken 사용 코드 제거 (#131)

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -14,9 +14,6 @@ function Navigation() {
   const [loading, setloading] = useState(false);
   const accessToken = getCookie("accessToken");
   useEffect(() => {
-    //refreshToken 갱신
-    isAuth();
-
     if (accessToken && accessToken !== null) {
       call("/no-permit/api/user/info", "GET", "").then((response) => {
         setUserInfo(response);


### PR DESCRIPTION
## 👀 이슈

resolve #131 

## 📌 개요

서버에서 **`refreshToken`** 을 반환하지 않음에 따라 `isAuth` 함수를
호출하여 에러가 발생하였습니다.

## 👩‍💻 작업 사항

`Navigation` 컴포넌트 내 **`isAuth`** 함수를 호출하는 코드를 제거하였습니다.

## ✅ 참고 사항