### PR TITLE
[bug]: 특정 게시판 내 게시글 정보 조회 시 발생하는 버그 제거 (#133)

### DIFF
--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -46,7 +46,7 @@ const PhotoList = () => {
   }, []);
 
   const onClickDetail = (list) => {
-    myRole().then((response)=>{
+    myRole().then((response) => {
       if (response === "member" || response === "admin") {
         navigate("./photoDetail", {
           state: {
@@ -54,14 +54,12 @@ const PhotoList = () => {
             articleId: list.id,
           },
         });
-      } 
-      else if (response ==="temp"){
+      } else if (response === "temp") {
         Swal.fire({
           icon: "info",
           title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+        });
+      } else {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
@@ -70,7 +68,6 @@ const PhotoList = () => {
             navigate("/login");
           }
         });
-
       }
     });
   };
@@ -80,7 +77,7 @@ const PhotoList = () => {
       {loading ? (
         <>
           <Row>
-            {photoList.map((list, i) => {
+            {photoList.content.map((list, i) => {
               let createDt = list.createDt.slice(0, 10);
               return (
                 <Col key={i}>

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -204,7 +204,7 @@ function ReportPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -204,7 +204,7 @@ function SeminarPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -204,7 +204,7 @@ function ProjectPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">


### PR DESCRIPTION
## 👀 이슈

resolve #133 

## 📌 개요

기존 게시글 정보를 조회할 때 사용하는 API가 변경됨에 따라서
데이터를 조회할 때 참조하는 속성이 추가되었지만, 해당 사항이
기존의 몇몇 코드에는 반영되어 있지 않아 특정 게시판 내에서는
정상적으로 등록된 게시글들이 표시되지 않는 문제가 있었습니다.

## 👩‍💻 작업 사항

- `세미나`, `활동 보고서`, `소규모 프로젝트`, `사진첩` 게시판  컴포넌트 코드 내
최신 기준의 API를 호출 시 받아오는 값으로 참조가 가능하게끔 알맞게 코드를 수정하였습니다.

## ✅ 참고 사항
- 해결 후 사진(정상적으로 게시판 내 게시글을 불러옴)

![스크린샷 2022-09-19 오후 10 44 53](https://user-images.githubusercontent.com/56868605/191033777-ac8570c1-4e2a-41d8-b666-7c87cd068794.png)
