### PR TITLE
[fix]: 컴포넌트 별로 유저의 권한에 알맞게 접근 또는 차단되도록 수정 (#128)

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,77 +1,81 @@
 import { call } from "./useFetch";
-import { setCookie, delCookie, getCookie} from './useCookie';
-import jwtDecode from 'jwt-decode'
+import { setCookie, delCookie, getCookie } from "./useCookie";
+import jwtDecode from "jwt-decode";
 
 //refreshToken 갱신
-export function isAuth(){
-    const accessToken = getCookie("accessToken");
-    const refreshToken = getCookie("refreshToken");
+export function isAuth() {
+  const accessToken = getCookie("accessToken");
+  const refreshToken = getCookie("refreshToken");
 
-    if((accessToken && accessToken !== null) || (refreshToken && refreshToken !== null))
-        call("/auth/reissue", "POST", "")
-        .then((response) => {
-            const todayDate = new Date();
-            try{
-                if(response.success){
-                    const decode = jwtDecode (response.response.accessToken);
-                    setCookie("accessToken", response.response.accessToken, decode.exp - todayDate.getTime()/1000);
+  if (
+    (accessToken && accessToken !== null) ||
+    (refreshToken && refreshToken !== null)
+  )
+    call("/auth/reissue", "POST", "").then((response) => {
+      const todayDate = new Date();
+      try {
+        if (response.success) {
+          const decode = jwtDecode(response.response.accessToken);
+          setCookie(
+            "accessToken",
+            response.response.accessToken,
+            decode.exp - todayDate.getTime() / 1000
+          );
 
-                    const decode2 = jwtDecode (response.response.refreshToken);
-                    setCookie("refreshToken", response.response.refreshToken, decode2.exp - todayDate.getTime()/1000);
-                    return response
-                    // window.location.href = "/";
-                }
-                else{
-                    return false;
-                }
-            }
-            catch(err){
-                return console.log(err)
-            }
-        })
+          const decode2 = jwtDecode(response.response.refreshToken);
+          setCookie(
+            "refreshToken",
+            response.response.refreshToken,
+            decode2.exp - todayDate.getTime() / 1000
+          );
+          return response;
+          // window.location.href = "/";
+        } else {
+          return false;
+        }
+      } catch (err) {
+        return console.log(err);
+      }
+    });
 }
 
-export function login(SignInRequest){
-    return call("/auth/login", "POST", SignInRequest).then((response)=>{
-        const todayDate = new Date();
-        try{
-            
-            if(response.response.accessToken){
-                const decode = jwtDecode (response.response.accessToken);
-                setCookie("accessToken", response.response.accessToken, decode.exp - todayDate.getTime()/1000);
-                return response
-                // window.location.href = "/";
-            }
-        }
-        catch{
-            return false
-        }
-        
+export function login(SignInRequest) {
+  return call("/auth/login", "POST", SignInRequest).then((response) => {
+    const todayDate = new Date();
+    try {
+      if (response.response.accessToken) {
+        const decode = jwtDecode(response.response.accessToken);
+        setCookie(
+          "accessToken",
+          response.response.accessToken,
+          decode.exp - todayDate.getTime() / 1000
+        );
+        return response;
+        // window.location.href = "/";
+      }
+    } catch {
+      return false;
     }
-    );
+  });
 }
 
-export function myRole(){
-
-    return call("/no-permit/api/user/info", "GET", '').then((response)=>{
-        if(response.success === false){
-            return "not authorized"
-        }
-        else if(response.response.role ==="ROLE_TEMP"){
-            return "temp"
-        }
-        else if(response.response.role === "ROLE_MEMBER") {
-            return "member"
-        }
-        else if(response.response.role === "ROLE_ADMIN") {
-            return "admin"
-        }
-    })
+export function myRole() {
+  return call("/no-permit/api/user/info", "GET", "").then((response) => {
+    if (response.success === false) {
+      return "not authorized";
+    } else if (response.response.role === "ROLE_TEMP") {
+      return "temp";
+    } else if (response.response.role === "ROLE_MEMBER") {
+      return "member";
+    } else if (response.response.role === "ROLE_ADMIN") {
+      return "admin";
+    }
+  });
 }
 
 export function signout() {
-    delCookie("accessToken")
-    delCookie("refreshToken")
+  delCookie("accessToken");
+  delCookie("refreshToken");
 
-    window.location.href = "/";
-  }
+  window.location.href = "/";
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -61,7 +61,7 @@ export function login(SignInRequest) {
 
 export function myRole() {
   return call("/no-permit/api/user/info", "GET", "").then((response) => {
-    if (response.success === false) {
+    if (!response) {
       return "not authorized";
     } else if (response.response.role === "ROLE_TEMP") {
       return "temp";

--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -53,48 +53,44 @@ function ExamPage() {
 
   const examUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./examUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./examUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/examDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("/examDetail", {
+          state: {
+            boardId,
+            articleId: list.id,
+          },
         });
       }
     });

--- a/src/pages/exam/ExamUpdate.js
+++ b/src/pages/exam/ExamUpdate.js
@@ -17,6 +17,24 @@ function ExamUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -57,26 +75,6 @@ function ExamUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -53,50 +53,48 @@ function FreeBoardPage() {
 
   const freeBoardUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./freeBoardUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./freeBoardUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/freeBoardDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
+      myRole().then((response) => {
+        if (response === "not authorized") {
+          Swal.fire({
+            icon: "error",
+            title: "로그인이 필요합니다.",
+          }).then((result) => {
             navigate("/login");
-          }
-        });
-      }
+          });
+        } else if (response === "temp") {
+          Swal.fire({
+            icon: "info",
+            title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+          });
+        } else {
+          navigate("/freeBoardDetail", {
+            state: {
+              boardId,
+              articleId: list.id,
+            },
+          });
+        }
+      });
     });
   };
 

--- a/src/pages/freeBoard/FreeBoardUpdate.js
+++ b/src/pages/freeBoard/FreeBoardUpdate.js
@@ -17,6 +17,24 @@ function FreeBoardUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -57,26 +75,6 @@ function FreeBoardUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/main/Board.js
+++ b/src/pages/main/Board.js
@@ -1,130 +1,112 @@
-import './Board.scss';
+import "./Board.scss";
 import { useEffect, useState } from "react";
 import { call } from "../../hooks/useFetch";
-import { useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
-import { myRole } from '../../hooks/useAuth';
-
+import { myRole } from "../../hooks/useAuth";
 
 function Board() {
-    const navigate = useNavigate();
-    const [announcements, setannouncements] = useState({});
-    const [loading, setloading] = useState(false);
-    const [boardId, setBoardId] = useState();
-    
-    useEffect(() => {
-        call("/no-permit/api/home/announcements", "GET", "")
-        .then((response) => {
-            setannouncements(response);
-            setloading(true);
-        })
+  const navigate = useNavigate();
+  const [announcements, setannouncements] = useState({});
+  const [loading, setloading] = useState(false);
+  const [boardId, setBoardId] = useState();
 
-        call("/no-permit/api/boards", "GET").then((response) => {
-            if (response.success) {
-              for (let i = 0; i < response.response.length; i++) {
-                if (response.response[i].name === "공지사항") {
-                  setBoardId(response.response[i].id);
-                }
-            }
+  useEffect(() => {
+    call("/no-permit/api/home/announcements", "GET", "").then((response) => {
+      setannouncements(response);
+      setloading(true);
+    });
+
+    call("/no-permit/api/boards", "GET").then((response) => {
+      if (response.success) {
+        for (let i = 0; i < response.response.length; i++) {
+          if (response.response[i].name === "공지사항") {
+            setBoardId(response.response[i].id);
+          }
         }
-    }
-)  
-    }, [])
-    
-    const onClickDetaile = (list) => {
-      myRole().then((response)=>{
-        if (response === "member" || response === "admin") {
-            navigate('/noticeDetail', {
-              state: {
-                  boardId : boardId,
-                  articleId : list.id
-                  ,
-              },
-            });
-          }
-          else if (response ==="temp"){
-            Swal.fire({
-              icon: "info",
-              title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-            })
-          }
-          else{
-            Swal.fire({
-              icon: "error",
-              title: "로그인이 필요합니다.",
-            }).then((result) => {
-              if (result.isConfirmed) {
-                navigate("/");
-              }
-            });
-          }
-          
-        })
-    
-      };
+      }
+    });
+  }, []);
 
-      
-    function BoardList({board}){
-        return(
-            <tr onClick={()=>{onClickDetaile(board)}}>
-                <td>
-                    <p>
-                        {board.id}
-                    </p>
-                </td>
-                <td>
-                    <p>
-                        {board.createDt.slice(0, 10)}
-                    </p>
-                </td>
-   
-                <td>
-                    <p>
-                        {board.title}
-                    </p>
-                </td>
-                <td>
-                    <p>
-                        {board.author}
-                    </p>
-                </td>
-            </tr>
-        );
-    }
+  const onClickDetaile = (list) => {
+    myRole().then((response) => {
+      if (response === "member" || response === "admin") {
+        navigate("/noticeDetail", {
+          state: {
+            boardId: boardId,
+            articleId: list.id,
+          },
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          if (result.isConfirmed) {
+            navigate("/");
+          }
+        });
+      }
+    });
+  };
+
+  function BoardList({ board }) {
     return (
-        <div className="Board">
-            <table>
-                <thead>
-                      <tr>
-                        <th scope="col" style={{ textAlign: "center" }}>
-                          #
-                        </th>
-                        <th scope="col" style={{ textAlign: "center" }}>
-                          날짜
-                        </th>
-      
-                        <th scope="col" style={{ textAlign: "center" }}>
-                          제목
-                        </th>
-                        <th scope="col" style={{ textAlign: "center" }}>
-                          작성자
-                        </th>
-                      </tr>
-                </thead>
-                {loading && announcements.success === true
-                ? 
-                <tbody>
-                {
-                    announcements.response.map((board, index)=>(<BoardList board={board} key={index}/>))
-                }
-                </tbody>
+      <tr
+        onClick={() => {
+          onClickDetaile(board);
+        }}
+      >
+        <td>
+          <p>{board.id}</p>
+        </td>
+        <td>
+          <p>{board.createDt.slice(0, 10)}</p>
+        </td>
 
+        <td>
+          <p>{board.title}</p>
+        </td>
+        <td>
+          <p>{board.author}</p>
+        </td>
+      </tr>
+    );
+  }
+  return (
+    <div className="Board">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col" style={{ textAlign: "center" }}>
+              #
+            </th>
+            <th scope="col" style={{ textAlign: "center" }}>
+              날짜
+            </th>
 
-                : null}
-               
-            </table>
-        </div>
-
-    )
+            <th scope="col" style={{ textAlign: "center" }}>
+              제목
+            </th>
+            <th scope="col" style={{ textAlign: "center" }}>
+              작성자
+            </th>
+          </tr>
+        </thead>
+        {loading && announcements.success === true ? (
+          <tbody>
+            {announcements.response.map((board, index) => (
+              <BoardList board={board} key={index} />
+            ))}
+          </tbody>
+        ) : null}
+      </table>
+    </div>
+  );
 }
 export default Board;

--- a/src/pages/main/Board.js
+++ b/src/pages/main/Board.js
@@ -28,30 +28,30 @@ function Board() {
     });
   }, []);
 
-  const onClickDetaile = (list) => {
+  const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/noticeDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
-        });
-      } else {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/");
-          }
-        });
-      }
+      myRole().then((response) => {
+        if (response === "not authorized") {
+          Swal.fire({
+            icon: "error",
+            title: "로그인이 필요합니다.",
+          }).then((result) => {
+            navigate("/login");
+          });
+        } else if (response === "temp") {
+          Swal.fire({
+            icon: "info",
+            title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+          });
+        } else {
+          navigate("/noticeDetail", {
+            state: {
+              boardId,
+              articleId: list.id,
+            },
+          });
+        }
+      });
     });
   };
 
@@ -59,7 +59,7 @@ function Board() {
     return (
       <tr
         onClick={() => {
-          onClickDetaile(board);
+          onClickDetail(board);
         }}
       >
         <td>

--- a/src/pages/management/ManagementPage.js
+++ b/src/pages/management/ManagementPage.js
@@ -9,24 +9,25 @@ import Swal from "sweetalert2";
 import { useNavigate } from "react-router-dom";
 
 function ManagementPage() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
-  useEffect(() => {
-    myRole().then((response)=>{
-      if (response !== "admin"){
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    })
-
-  }, [navigate])
-  
+  myRole().then((response) => {
+    if (response === "not authorized") {
+      Swal.fire({
+        icon: "error",
+        title: "로그인이 필요합니다.",
+      }).then((result) => {
+        navigate("/login");
+      });
+    } else if (response !== "admin") {
+      Swal.fire({
+        icon: "info",
+        title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+      }).then((result) => {
+        navigate("/login");
+      });
+    }
+  });
 
   const [visible, setVisible] = useState("hidden");
   const isSchedule = (event) => {
@@ -36,8 +37,6 @@ function ManagementPage() {
       setVisible("hidden");
     }
   };
-
-
 
   return (
     <div className="ManagementPage">
@@ -82,7 +81,7 @@ function ManagementPage() {
               </Tab.Pane>
               <Tab.Pane eventKey="fourth">
                 <h1>회원 관리</h1>
-                <MemberManage/>
+                <MemberManage />
               </Tab.Pane>
               <Tab.Pane eventKey="fifth">
                 <h1>기타 관리</h1>

--- a/src/pages/modifyUserInfo/CheckPwPage.js
+++ b/src/pages/modifyUserInfo/CheckPwPage.js
@@ -11,24 +11,23 @@ function CheckPwPage() {
 
   const [UserInfo, setUserInfo] = useState({});
   const [loading, setloading] = useState(false);
-  useEffect(() => {
-    myRole().then((response) => {
-      if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          navigate("/login");
-        });
-      }
-    });
 
-    call("/api/user/info", "GET", "").then((response) => {
-      setUser({ studentId: response.response.studentId });
-      setUserInfo(response.response);
-      setloading(true);
-    });
-  }, []);
+  myRole().then((response) => {
+    if (response === "not authorized") {
+      Swal.fire({
+        icon: "error",
+        title: "로그인이 필요합니다.",
+      }).then((result) => {
+        navigate("/login");
+      });
+    }
+  });
+
+  call("/api/user/info", "GET", "").then((response) => {
+    setUser({ studentId: response.response.studentId });
+    setUserInfo(response.response);
+    setloading(true);
+  });
 
   function passwordCheck(e) {
     e.preventDefault();

--- a/src/pages/modifyUserInfo/CheckPwPage.js
+++ b/src/pages/modifyUserInfo/CheckPwPage.js
@@ -1,114 +1,157 @@
 import "./CheckPwPage.scss";
 import { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom";
 import { call } from "../../hooks/useFetch";
-import { login } from "../../hooks/useAuth"
-import Swal from "sweetalert2"
+import { login, myRole } from "../../hooks/useAuth";
+import Swal from "sweetalert2";
 function CheckPwPage() {
   const navigate = useNavigate();
-  
-  const [User, setUser] = useState({"studentId":"", "password" : ""});
 
-  const [UserInfo, setUserInfo] = useState({})
-  const [loading, setloading] = useState(false) 
+  const [User, setUser] = useState({ studentId: "", password: "" });
+
+  const [UserInfo, setUserInfo] = useState({});
+  const [loading, setloading] = useState(false);
   useEffect(() => {
-    call("/api/user/info", "GET", "").then(
-      (response)=>{
-        setUser({"studentId" : response.response.studentId});
-        setUserInfo(response.response);
-        setloading(true);
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
       }
-    )
+    });
+
+    call("/api/user/info", "GET", "").then((response) => {
+      setUser({ studentId: response.response.studentId });
+      setUserInfo(response.response);
+      setloading(true);
+    });
   }, []);
 
-  function passwordCheck(e){
+  function passwordCheck(e) {
     e.preventDefault();
     const checkPwBtn = document.getElementById("checkPwBtn");
-    checkPwBtn.setAttribute('disabled', true);
-    checkPwBtn.innerText = "확인 중..."
-    checkPwBtn.style.color="white";
+    checkPwBtn.setAttribute("disabled", true);
+    checkPwBtn.innerText = "확인 중...";
+    checkPwBtn.style.color = "white";
     //로그인 call
-    login(User).then((response)=>{
-      if(response.success){
-          navigate('/modifyUserInfo', {"state" : true})
+    login(User).then((response) => {
+      if (response.success) {
+        navigate("/modifyUserInfo", { state: true });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "비밀번호가 틀립니다.",
+        }).then((result) => {
+          if (result) {
+            checkPwBtn.removeAttribute("disabled");
+            checkPwBtn.innerText = "확인";
+          }
+        });
       }
-      else{
-          Swal.fire({
-              icon: 'error',
-              title: '비밀번호가 틀립니다.',
-            }).then((result)=>{
-              if(result){
-                checkPwBtn.removeAttribute('disabled');
-                checkPwBtn.innerText = "확인"
-            }
-            });
-      }
-  });
+    });
   }
-  
-  return(
-      <div className="CheckPwPage container">
-          <div className="titleFrame">
-              <h5><strong><i className="fas fa-map-marker-alt "></i> &nbsp;회원 비밀번호 확인</strong></h5>
-              <div>
-                  <Link to={"/"}>Home</Link> &nbsp;/&nbsp; 정보수정
-              </div>
-          </div>
-          <hr/>
-          <form onSubmit={(e)=>{passwordCheck(e)}}>
-          <table>
-              <thead>
-                  <tr>
-                      <td colSpan={"3"}>
-                          <h5>
-                              <strong>회원 비밀번호 입력</strong>
-                          </h5>
-                      </td>
-                  </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    <p className="titleText">비밀번호를 한번 더 입력해주세요.</p>
-                    <p className="titleText">Note : <span> 회원님의 정보를 안전하게 보호하기 위해 비밀번호를 한번 더 확인합니다. </span></p>
-                    <hr/>
-                  </td>
-          
-                </tr>
 
-                <tr>
-                  <td>
-                    <p className="titleText">회원 아이디 : <span className="uId">{loading ? UserInfo.studentId : null}</span></p>
-                    <hr/>
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>  
-                    <label htmlFor="userPw" className="titleText">비밀번호</label><br/>
-                      
-                    <div className="inputText">
-                        <i className="fas fa-lock fa-lg"></i>
-                        <input type={"password"} autoComplete="current-password" id="userPw" title="최소 8자리에서 최대 20자리까지 숫자, 영문, 특수문자 각 1개 이상 포함해주세요." pattern="^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$" required onChange={(e) =>{setUser({...User, "password" : e.target.value})}}></input>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-              <thead>
-                    <tr>
-                        <td colSpan={"3"}>
-                            <button id="checkPwBtn" type="submit"><h5>확인</h5></button>
-                        </td>
-                    </tr>
-                </thead>
-            </table>
-          </form>
-          <div className="mainBtn">
-            <button type="button" onClick={()=>navigate('/')}><h5>메인으로 돌아가기</h5></button>
-          </div>
-          
+  return (
+    <div className="CheckPwPage container">
+      <div className="titleFrame">
+        <h5>
+          <strong>
+            <i className="fas fa-map-marker-alt "></i> &nbsp;회원 비밀번호 확인
+          </strong>
+        </h5>
+        <div>
+          <Link to={"/"}>Home</Link> &nbsp;/&nbsp; 정보수정
+        </div>
       </div>
-  );
-  }
+      <hr />
+      <form
+        onSubmit={(e) => {
+          passwordCheck(e);
+        }}
+      >
+        <table>
+          <thead>
+            <tr>
+              <td colSpan={"3"}>
+                <h5>
+                  <strong>회원 비밀번호 입력</strong>
+                </h5>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <p className="titleText">비밀번호를 한번 더 입력해주세요.</p>
+                <p className="titleText">
+                  Note :{" "}
+                  <span>
+                    {" "}
+                    회원님의 정보를 안전하게 보호하기 위해 비밀번호를 한번 더
+                    확인합니다.{" "}
+                  </span>
+                </p>
+                <hr />
+              </td>
+            </tr>
 
-  export default CheckPwPage
+            <tr>
+              <td>
+                <p className="titleText">
+                  회원 아이디 :{" "}
+                  <span className="uId">
+                    {loading ? UserInfo.studentId : null}
+                  </span>
+                </p>
+                <hr />
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label htmlFor="userPw" className="titleText">
+                  비밀번호
+                </label>
+                <br />
+
+                <div className="inputText">
+                  <i className="fas fa-lock fa-lg"></i>
+                  <input
+                    type={"password"}
+                    autoComplete="current-password"
+                    id="userPw"
+                    title="최소 8자리에서 최대 20자리까지 숫자, 영문, 특수문자 각 1개 이상 포함해주세요."
+                    pattern="^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$"
+                    required
+                    onChange={(e) => {
+                      setUser({ ...User, password: e.target.value });
+                    }}
+                  ></input>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+          <thead>
+            <tr>
+              <td colSpan={"3"}>
+                <button id="checkPwBtn" type="submit">
+                  <h5>확인</h5>
+                </button>
+              </td>
+            </tr>
+          </thead>
+        </table>
+      </form>
+      <div className="mainBtn">
+        <button type="button" onClick={() => navigate("/")}>
+          <h5>메인으로 돌아가기</h5>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CheckPwPage;

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -55,50 +55,48 @@ function NoticePage(props) {
 
   const onClickRegister = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/notice/noticeUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response !== "admin") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./noticeUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/noticeDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
+      myRole().then((response) => {
+        if (response === "not authorized") {
+          Swal.fire({
+            icon: "error",
+            title: "로그인이 필요합니다.",
+          }).then((result) => {
             navigate("/login");
-          }
-        });
-      }
+          });
+        } else if (response === "temp") {
+          Swal.fire({
+            icon: "info",
+            title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+          });
+        } else {
+          navigate("/noticeDetail", {
+            state: {
+              boardId,
+              articleId: list.id,
+            },
+          });
+        }
+      });
     });
   };
 

--- a/src/pages/notice/NoticeUpdate.js
+++ b/src/pages/notice/NoticeUpdate.js
@@ -17,6 +17,24 @@ function NoticeRegisteration() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp" || response === "member") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -56,27 +74,6 @@ function NoticeRegisteration() {
       "article",
       new Blob([JSON.stringify(notice)], { type: "application/json" })
     );
-
-
-    myRole().then((response)=>{
-
-    if (response === "temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-    else if(response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -11,8 +11,7 @@ const PhotoList = () => {
   const navigate = useNavigate();
   const [photoList, setPhotoList] = useState({});
   const [loading, setloading] = useState(false);
-  const [boardid, setBoardid] = useState();
-  const [colMd, setColMd] = useState(3);
+  const [boardId, setBoardid] = useState();
 
   useEffect(() => {
     call("/no-permit/api/boards", "GET").then((response) => {
@@ -43,34 +42,30 @@ const PhotoList = () => {
         });
       }
     });
+    console.log(photoList);
   }, []);
 
   const onClickDetail = (list) => {
-    myRole().then((response)=>{
-      if (response === "member" || response === "admin") {
-        navigate("./photoDetail", {
-          state: {
-            boardId: boardid,
-            articleId: list.id,
-          },
-        });
-      } 
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+    myRole().then((response) => {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
-
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./photoDetail", {
+          state: {
+            boardId,
+            articleId: list.id,
+          },
+        });
       }
     });
   };
@@ -98,7 +93,7 @@ const PhotoList = () => {
                       alt="사진첩 사진"
                       src={
                         "http://localhost:8080/no-permit/api/boards/" +
-                        boardid +
+                        boardId +
                         "/articles/" +
                         list.id +
                         "/files/" +

--- a/src/pages/photo/PhotoPage.js
+++ b/src/pages/photo/PhotoPage.js
@@ -12,27 +12,22 @@ function PhotoPage() {
 
   const photoUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./photoUpdate");
-      }
-      else if (response ==="temp"){
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./photoUpdate");
       }
     });
-
   };
 
   return (

--- a/src/pages/photo/PhotoUpdate.js
+++ b/src/pages/photo/PhotoUpdate.js
@@ -24,6 +24,24 @@ function PhotoUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -115,26 +133,6 @@ function PhotoUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -53,48 +53,44 @@ function ReportPage() {
 
   const reportUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./reportUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./reportUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/reportDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("/reportDetail", {
+          state: {
+            boardId,
+            articleId: list.id,
+          },
         });
       }
     });
@@ -204,7 +200,7 @@ function ReportPage() {
           </div>
           {loading ? (
             <>
-              {boardlist.map((list, i) => {
+              {boardlist.content.map((list, i) => {
                 let createDt = list.createDt.slice(0, 10);
                 return (
                   <div key={i} className="eachContents">

--- a/src/pages/report/ReportUpdate.js
+++ b/src/pages/report/ReportUpdate.js
@@ -17,6 +17,24 @@ function ReportUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -57,26 +75,6 @@ function ReportUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -53,48 +53,44 @@ function SeminarPage() {
 
   const seminarUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./seminarUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./seminarUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/seminarDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("/seminarDetail", {
+          state: {
+            boardId,
+            articleId: list.id,
+          },
         });
       }
     });

--- a/src/pages/seminar/SeminarUpdate.js
+++ b/src/pages/seminar/SeminarUpdate.js
@@ -17,6 +17,24 @@ function SeminarUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -57,26 +75,6 @@ function SeminarUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -53,48 +53,44 @@ function ProjectPage() {
 
   const examUpload = () => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("./projectUpdate");
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
         });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("./projectUpdate");
       }
     });
   };
 
   const onClickDetail = (list) => {
     myRole().then((response) => {
-      if (response === "member" || response === "admin") {
-        navigate("/projectDetail", {
-          state: {
-            boardId: boardId,
-            articleId: list.id,
-          },
-        });
-      } else if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        });
-      } else {
+      if (response === "not authorized") {
         Swal.fire({
           icon: "error",
           title: "로그인이 필요합니다.",
         }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        });
+      } else {
+        navigate("/projectDetail", {
+          state: {
+            boardId,
+            articleId: list.id,
+          },
         });
       }
     });

--- a/src/pages/subProject/ProjectUpdate.js
+++ b/src/pages/subProject/ProjectUpdate.js
@@ -17,6 +17,24 @@ function ProjectUpdate() {
   const [refreshTokenValue, setRefreshTokenValue] = useState("");
 
   useEffect(() => {
+    myRole().then((response) => {
+      if (response === "not authorized") {
+        Swal.fire({
+          icon: "error",
+          title: "로그인이 필요합니다.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      } else if (response === "temp") {
+        Swal.fire({
+          icon: "info",
+          title: "접근 권한이 없습니다. 관리자에게 문의해 주세요.",
+        }).then((result) => {
+          navigate("/login");
+        });
+      }
+    });
+
     const accessToken = getCookie("accessToken");
     const refreshToken = getCookie("refreshToken");
     if (accessToken && accessToken !== null) {
@@ -57,26 +75,6 @@ function ProjectUpdate() {
       "article",
       new Blob([JSON.stringify(photo)], { type: "application/json" })
     );
-
-    myRole().then((response) => {
-
-      if (response === "temp") {
-        Swal.fire({
-          icon: "info",
-          title: "접근 권한이 없습니다. <br/> 관리자에게 문의해 주세요.",
-        })
-      }
-      else if (response === "not authorized") {
-        Swal.fire({
-          icon: "error",
-          title: "로그인이 필요합니다.",
-        }).then((result) => {
-          if (result.isConfirmed) {
-            navigate("/login");
-          }
-        });
-      }
-    });
 
     let headers = {
       "Content-Type": "application/json",


### PR DESCRIPTION
## 👀 이슈

resolve #128 

## 📌 개요

로그인 후 유저의 권한에 따라 특정 작업을 수행  또는 차단되도록 하여야
하는데, 해당 부분에 대하여 모호한 컴포넌트들이 확인하였습니다.

## 👩‍💻 작업 사항

- `비회원`에 대한 권한 처리가 가능하도록 코드 수정
- `관리자 페이지` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `정보 수정` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `자유게시판` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `공지사항` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `특강자료` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `활동 보고서` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `소규모 프로젝트` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `족보` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정
- `사진첩` 컴포넌트에 접근 시 유저 권한에 알맞게 접근이 가능하도록 코드 수정

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
