### PR TITLE
[bug]: 사진첩 게시판 내 Pagination 버그 수정 (#159)

### DIFF
--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -43,17 +43,17 @@ const PhotoList = () => {
 
   /** Pagination 버튼을 생성하는 함수 */
   const addingPaginationItem = () => {
-    if (!Object.keys(photoList).length) return;
+    if (!photoList.totalElements) return;
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(
-          <Pagination.Item
-              active={pageNum === pageList + k}
-              key={k}
-              onClick={() => setPageNum(pageList + k)}
-          >
-            {pageList + k}
-          </Pagination.Item>
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
       );
       if (pageList + k === photoList.totalPages) break;
     }
@@ -83,64 +83,64 @@ const PhotoList = () => {
   };
 
   return (
-      <div className="photoMain" style={{ display: "flex" }}>
-        {loading ? (
-            <>
-              <Row>
-                {photoList.content.map((list, i) => {
-                  let createDt = list.createDt.slice(0, 10);
-                  return (
-                      <Col key={i}>
-                        <div
-                            style={{ cursor: "pointer" }}
-                            onClick={() => {
-                              onClickDetail(list);
-                            }}
-                            className="eachPost shadow"
-                        >
+    <div className="photoMain" style={{ display: "flex" }}>
+      {loading ? (
+        <>
+          <Row>
+            {photoList.content.map((list, i) => {
+              let createDt = list.createDt.slice(0, 10);
+              return (
+                <Col key={i}>
+                  <div
+                    style={{ cursor: "pointer" }}
+                    onClick={() => {
+                      onClickDetail(list);
+                    }}
+                    className="eachPost shadow"
+                  >
                     <span className="hoverViewCnt">
                       Views <span>{list.viewCnt}</span>
                     </span>
-                          <img
-                              alt="사진첩 사진"
-                              src={
-                                  process.env.REACT_APP_URL +
-                                  "/no-permit/api/boards/" +
-                                  boardId +
-                                  "/articles/" +
-                                  list.id +
-                                  "/files/" +
-                                  list.files[0].filePath
-                              }
-                              style={{
-                                width: "100%",
-                                height: "100%",
-                              }}
-                          ></img>
-                          <br />
-                          <br />
-                          <strong>{list.title}</strong>
-                          <hr />
-                          <span>
+                    <img
+                      alt="사진첩 사진"
+                      src={
+                        process.env.REACT_APP_URL +
+                        "/no-permit/api/boards/" +
+                        boardId +
+                        "/articles/" +
+                        list.id +
+                        "/files/" +
+                        list.files[0].filePath
+                      }
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                      }}
+                    ></img>
+                    <br />
+                    <br />
+                    <strong>{list.title}</strong>
+                    <hr />
+                    <span>
                       {list.author} | {createDt}
                     </span>
-                        </div>
-                      </Col>
-                  );
-                })}
-              </Row>
-            </>
-        ) : null}
-        <div className="pageNum">
-          <Pagination>
-            <Pagination.First onClick={() => onChangingPage("first")} />
-            <Pagination.Prev onClick={() => onChangingPage("prev")} />
-            {addingPaginationItem()}
-            <Pagination.Next onClick={() => onChangingPage("next")} />
-            <Pagination.Last onClick={() => onChangingPage("last")} />
-          </Pagination>
-        </div>
+                  </div>
+                </Col>
+              );
+            })}
+          </Row>
+        </>
+      ) : null}
+      <div className="pageNum">
+        <Pagination>
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
+        </Pagination>
       </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 👀 이슈

resolve #159 

## 📌 개요

사진첩 게시판 내에 게시글이 하나도 등록되어 있지 않을 때 페이지 넘버가
나타나지 않도록 설계했던 부분이 잘못되어 페이지 넘버가 의도와는 다르게
표시되는 버그가 발견되었습니다.

## 👩‍💻 작업 사항

- **`PhotoList.js`** 컴포넌트 내 코드 수정

## ✅ 참고 사항

- 해결 전 사진

<img width="1001" alt="스크린샷 2022-09-24 오후 1 51 25" src="https://user-images.githubusercontent.com/56868605/192080638-83495cff-6dd9-4c8f-a3f3-dcdd556d2923.png">

- 해결 후 사진

<img width="1002" alt="스크린샷 2022-09-24 오후 1 52 50" src="https://user-images.githubusercontent.com/56868605/192080642-a7977803-57d1-4f26-b8d9-42097e9a7aea.png">