### PR TITLE
[fix]: 회원 메뉴 클릭 시 이동 주소 수정 (#164)

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -4,21 +4,18 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { signout } from "../hooks/useAuth";
 import { useEffect, useState } from "react";
 import { Helmet, HelmetProvider } from "react-helmet-async";
-import {getCookie} from "../hooks/useCookie";
+import { getCookie } from "../hooks/useCookie";
 
 function Navigation() {
-  const [show1, setShow1] = useState(false);
-
   const navigate = useNavigate();
   const location = useLocation();
   const [userInfo, setUserInfo] = useState({});
   const [loading, setloading] = useState(false);
 
-
-  useEffect( () => {
-    if(getCookie('SammaruAccessToken')){
-      api.get("/no-permit/api/user/info").then(response => {
-        if(response.data.success) {
+  useEffect(() => {
+    if (getCookie("SammaruAccessToken")) {
+      api.get("/no-permit/api/user/info").then((response) => {
+        if (response.data.success) {
           console.log(response.data.response);
           setUserInfo(response.data);
           setloading(true);
@@ -99,7 +96,7 @@ function Navigation() {
                 </a>
               </li>
               <li>
-                <a href={"/member"} style={{ color: "#878787" }}>
+                <a href={"/member/1"} style={{ color: "#878787" }}>
                   회원
                 </a>
                 <ul>


### PR DESCRIPTION
## 👀 이슈

resolve #164 

## 📌 개요

샘마루 메뉴의 세부 메뉴 중 회원 클릭 시 /memeber 주소로 이동되는데 Router.js 파일 내
별도의 컴포넌트 지정이 없어서 /member1 컴포넌트를 불러오도록 변경하고자 하였습니다.

## 👩‍💻 작업 사항

`Navigation.js` 파일 내 이동 주소 수정

## ✅ 참고 사항

- 현재 메뉴바에서 **`회원`** 클릭 시 1기 멤버 페이지로 이동하는데
추후 기수 설정 컴포넌트가 완성되면 가장 최신 기수가 저장된 정보가
화면에 보일 수 있도록 수정할 계획입니다.
