### PR TITLE
[refactor]: Accesstoken 만료 확인 후 토큰 제거 기능 모듈화 및 회원검색 오류 제거 (#179)

### DIFF
--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -3,7 +3,7 @@ import api from "../utils/api";
 import { useNavigate } from "react-router-dom";
 import "./Comment.scss";
 import Swal from "sweetalert2";
-import { delCookie, getCookie } from "../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../hooks/useAuth";
 
 function Comment(props) {
   const navigate = useNavigate();
@@ -57,27 +57,10 @@ function Comment(props) {
       });
   }, [props]);
 
-  const insertComment = async () => {
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
-
-    async function getUserInfo() {
-      try {
-        await api
+  const insertComment = () => {
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        api
           .post(
             "/api/boards/" +
               props.boardId +
@@ -109,13 +92,8 @@ function Comment(props) {
               });
             }
           });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const change_page = (event, value) => {

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -16,6 +16,36 @@ export function myRole() {
   });
 }
 
+export async function checkExpiredAccesstoken() {
+  function expiredLogin() {
+    Swal.fire({
+      title: "로그인 상태 허용 시간이 초과되었습니다.",
+      text: "로그인 페이지로 다시 이동하시겠습니까?",
+      icon: "error",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        window.location.href = "/login";
+      }
+    });
+  }
+
+  if (getCookie("SammaruAccessToken")) {
+    try {
+      return await api.get("/no-permit/api/user/info").then((response) => {
+        return response;
+      });
+    } catch (error) {
+      delCookie("SammaruAccessToken");
+      expiredLogin();
+    }
+  } else expiredLogin();
+}
+
 export function signout() {
   api.delete("/auth/logout").then((response) => {
     window.location.href = "/";

--- a/src/pages/exam/ExamUpdate.js
+++ b/src/pages/exam/ExamUpdate.js
@@ -4,7 +4,7 @@ import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function ExamUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -26,66 +26,42 @@ function ExamUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const examBtn = document.getElementById("examBtn");
+        examBtn.setAttribute("disabled", true);
+        examBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const examBtn = document.getElementById("examBtn");
-          examBtn.setAttribute("disabled", true);
-          examBtn.innerText = "글등록 중...";
+        let formData = new FormData();
 
-          let formData = new FormData();
+        formData.append("file", uploadFile[0]);
 
-          formData.append("file", uploadFile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/exam");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/exam");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {

--- a/src/pages/freeBoard/FreeBoardUpdate.js
+++ b/src/pages/freeBoard/FreeBoardUpdate.js
@@ -4,7 +4,7 @@ import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function FreeBoardUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -26,66 +26,42 @@ function FreeBoardUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const freeBoardBtn = document.getElementById("freeBoardBtn");
+        freeBoardBtn.setAttribute("disabled", true);
+        freeBoardBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const freeBoardBtn = document.getElementById("freeBoardBtn");
-          freeBoardBtn.setAttribute("disabled", true);
-          freeBoardBtn.innerText = "글등록 중...";
+        let formData = new FormData();
 
-          let formData = new FormData();
+        formData.append("file", uploadFile[0]);
 
-          formData.append("file", uploadFile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/freeBoard");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/freeBoard");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {

--- a/src/pages/management/BoardManage.js
+++ b/src/pages/management/BoardManage.js
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function BoardManage() {
   const [board, setBoard] = useState({ boardName: "", description: "" });
@@ -12,51 +12,27 @@ function BoardManage() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
-
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          api.post("/api/boards", board).then((response) => {
-            if (response.data.success) {
-              Swal.fire({
-                icon: "success",
-                title: "게시판 생성을 성공했습니다.",
-              }).then((result) => {
-                if (result.isConfirmed) {
-                  navigate("/");
-                }
-              });
-            } else {
-              Swal.fire({
-                icon: "error",
-                title: "게시판 생성을 실패했습니다.",
-              });
-            }
-          });
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        api.post("/api/boards", board).then((response) => {
+          if (response.data.success) {
+            Swal.fire({
+              icon: "success",
+              title: "게시판 생성을 성공했습니다.",
+            }).then((result) => {
+              if (result.isConfirmed) {
+                navigate("/");
+              }
+            });
+          } else {
+            Swal.fire({
+              icon: "error",
+              title: "게시판 생성을 실패했습니다.",
+            });
+          }
         });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   return (

--- a/src/pages/modifyUserInfo/CheckPwPage.js
+++ b/src/pages/modifyUserInfo/CheckPwPage.js
@@ -4,7 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
 import axios from "axios";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function CheckPwPage() {
   const navigate = useNavigate();
@@ -23,62 +23,38 @@ function CheckPwPage() {
 
   function passwordCheck(e) {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
-
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const checkPwBtn = document.getElementById("checkPwBtn");
-          checkPwBtn.setAttribute("disabled", true);
-          checkPwBtn.innerText = "확인 중...";
-          checkPwBtn.style.color = "white";
-          //로그인 call
-          axios
-            .post(
-              process.env.REACT_APP_URL + "/auth/login",
-              { ...User },
-              { withCredentials: true }
-            )
-            .then((response) => {
-              if (response.data.success)
-                navigate("/modifyUserInfo", { state: true });
-            })
-            .catch((error) => {
-              if (error.response.status === 401) {
-                Swal.fire({
-                  icon: "error",
-                  title: "현재 비밀번호와 일치하지 않습니다.",
-                }).then((result) => {
-                  if (result) {
-                    checkPwBtn.removeAttribute("disabled");
-                    checkPwBtn.innerText = "확인";
-                  }
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const checkPwBtn = document.getElementById("checkPwBtn");
+        checkPwBtn.setAttribute("disabled", true);
+        checkPwBtn.innerText = "확인 중...";
+        checkPwBtn.style.color = "white";
+        //로그인 call
+        axios
+          .post(
+            process.env.REACT_APP_URL + "/auth/login",
+            { ...User },
+            { withCredentials: true }
+          )
+          .then((response) => {
+            if (response.data.success)
+              navigate("/modifyUserInfo", { state: true });
+          })
+          .catch((error) => {
+            if (error.response.status === 401) {
+              Swal.fire({
+                icon: "error",
+                title: "현재 비밀번호와 일치하지 않습니다.",
+              }).then((result) => {
+                if (result) {
+                  checkPwBtn.removeAttribute("disabled");
+                  checkPwBtn.innerText = "확인";
+                }
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   }
 
   return (

--- a/src/pages/modifyUserInfo/ModifyUserInfoPage.js
+++ b/src/pages/modifyUserInfo/ModifyUserInfoPage.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
 import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function ModifyUserInfoPage() {
   const navigate = useNavigate();
@@ -42,22 +43,6 @@ function ModifyUserInfoPage() {
 
   function modifyUser(e) {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
 
     async function modifyingUserInfo() {
       const modifyUserBtn = document.getElementById("modifyUserBtn");
@@ -92,34 +77,27 @@ function ModifyUserInfoPage() {
       }
     }
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const modifyUserBtn = document.getElementById("modifyUserBtn");
-          modifyUserBtn.setAttribute("disabled", true);
-          modifyUserBtn.innerText = "정보수정 중...";
-          modifyUserBtn.style.color = "white";
-          if (User.password !== pwCheck2) {
-            Swal.fire({
-              title: "비밀번호가 일치하지 않습니다.",
-              icon: "warning",
-            }).then((result) => {
-              if (result) {
-                modifyUserBtn.removeAttribute("disabled");
-                modifyUserBtn.innerText = "정보수정";
-              }
-            });
-          } else {
-            modifyingUserInfo();
-          }
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const modifyUserBtn = document.getElementById("modifyUserBtn");
+        modifyUserBtn.setAttribute("disabled", true);
+        modifyUserBtn.innerText = "정보수정 중...";
+        modifyUserBtn.style.color = "white";
+        if (User.password !== pwCheck2) {
+          Swal.fire({
+            title: "비밀번호가 일치하지 않습니다.",
+            icon: "warning",
+          }).then((result) => {
+            if (result) {
+              modifyUserBtn.removeAttribute("disabled");
+              modifyUserBtn.innerText = "정보수정";
+            }
+          });
+        } else {
+          modifyingUserInfo();
+        }
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   }
 
   return (

--- a/src/pages/notice/NoticeUpdate.js
+++ b/src/pages/notice/NoticeUpdate.js
@@ -4,8 +4,7 @@ import Swal from "sweetalert2";
 import api from "../../utils/api";
 import { useNavigate } from "react-router-dom";
 import { getBoardList } from "../../hooks/boardServices";
-import { myRole } from "../../hooks/useAuth";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken, myRole } from "../../hooks/useAuth";
 
 function NoticeRegisteration() {
   const [boardId, setBoardId] = useState(0);
@@ -37,67 +36,43 @@ function NoticeRegisteration() {
     });
   }, []);
 
-  const onSubmit = async (e) => {
+  const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const noticeBtn = document.getElementById("noticeBtn");
+        noticeBtn.setAttribute("disabled", true);
+        noticeBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const noticeBtn = document.getElementById("noticeBtn");
-          noticeBtn.setAttribute("disabled", true);
-          noticeBtn.innerText = "글등록 중...";
+        let formData = new FormData();
+        formData.append("file", uploadfile[0]);
 
-          let formData = new FormData();
-          formData.append("file", uploadfile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(notice)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(notice)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/notice");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/notice");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {

--- a/src/pages/photo/PhotoUpdate.js
+++ b/src/pages/photo/PhotoUpdate.js
@@ -10,7 +10,7 @@ import "./PhotoUpdate.scss";
 import { Navigation } from "swiper";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function PhotoUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -70,80 +70,56 @@ function PhotoUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const photoBtn = document.getElementById("photoBtn");
+        photoBtn.setAttribute("disabled", true);
+        photoBtn.innerText = "글등록 중...";
+
+        if (uploadfile[0] === undefined) {
+          Swal.fire({
+            icon: "error",
+            title: "사진을 추가해주세요.",
+          }).then((result) => {
+            if (result) {
+              photoBtn.removeAttribute("disabled");
+              photoBtn.innerText = "작성완료";
+            }
+          });
+          return;
         }
-      });
-    }
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const photoBtn = document.getElementById("photoBtn");
-          photoBtn.setAttribute("disabled", true);
-          photoBtn.innerText = "글등록 중...";
+        let formData = new FormData();
+        for (let i = 0; i < uploadfile.length; i++) {
+          formData.append("file", uploadfile[i]);
+        }
 
-          if (uploadfile[0] === undefined) {
-            Swal.fire({
-              icon: "error",
-              title: "사진을 추가해주세요.",
-            }).then((result) => {
-              if (result) {
-                photoBtn.removeAttribute("disabled");
-                photoBtn.innerText = "작성완료";
-              }
-            });
-            return;
-          }
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          let formData = new FormData();
-          for (let i = 0; i < uploadfile.length; i++) {
-            formData.append("file", uploadfile[i]);
-          }
-
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/photo");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/photo");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {

--- a/src/pages/report/ReportUpdate.js
+++ b/src/pages/report/ReportUpdate.js
@@ -4,7 +4,7 @@ import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function ReportUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -26,66 +26,42 @@ function ReportUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const examBtn = document.getElementById("examBtn");
+        examBtn.setAttribute("disabled", true);
+        examBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const examBtn = document.getElementById("examBtn");
-          examBtn.setAttribute("disabled", true);
-          examBtn.innerText = "글등록 중...";
+        let formData = new FormData();
 
-          let formData = new FormData();
+        formData.append("file", uploadfile[0]);
 
-          formData.append("file", uploadfile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/report");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/report");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {
@@ -150,15 +126,21 @@ function ReportUpdate() {
             }}
           />
         </Form.Group>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <Button
+            id="examBtn"
+            variant="dark"
+            type="submit"
+            size="lg"
+            onClick={onSubmit}
+          >
+            작성완료
+          </Button>
+          <Button variant="grey" size="lg" onClick={handlePostCancel}>
+            작성취소
+          </Button>
+        </div>
       </Form>
-      <div style={{ display: "flex", justifyContent: "center" }}>
-        <Button id="examBtn" variant="dark" type="submit" size="lg">
-          작성완료
-        </Button>
-        <Button variant="grey" size="lg" onClick={handlePostCancel}>
-          작성취소
-        </Button>
-      </div>
     </div>
   );
 }

--- a/src/pages/seminar/SeminarUpdate.js
+++ b/src/pages/seminar/SeminarUpdate.js
@@ -4,7 +4,7 @@ import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function SeminarUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -26,66 +26,42 @@ function SeminarUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const examBtn = document.getElementById("examBtn");
+        examBtn.setAttribute("disabled", true);
+        examBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const examBtn = document.getElementById("examBtn");
-          examBtn.setAttribute("disabled", true);
-          examBtn.innerText = "글등록 중...";
+        let formData = new FormData();
 
-          let formData = new FormData();
+        formData.append("file", uploadfile[0]);
 
-          formData.append("file", uploadfile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/seminar");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/seminar");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {

--- a/src/pages/subProject/ProjectUpdate.js
+++ b/src/pages/subProject/ProjectUpdate.js
@@ -4,7 +4,7 @@ import { Form, Button } from "react-bootstrap";
 import Swal from "sweetalert2";
 import { getBoardList } from "../../hooks/boardServices";
 import api from "../../utils/api";
-import { delCookie, getCookie } from "../../hooks/useCookie";
+import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 
 function ProjectUpdate() {
   const [boardId, setBoardId] = useState(0);
@@ -26,66 +26,42 @@ function ProjectUpdate() {
 
   const onSubmit = (e) => {
     e.preventDefault();
-    function expiredLogin() {
-      Swal.fire({
-        title: "로그인 상태 허용 시간이 초과되었습니다.",
-        text: "로그인 페이지로 다시 이동하시겠습니까?",
-        icon: "error",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
-      }).then((result) => {
-        if (result.isConfirmed) {
-          window.location.href = "/login";
-        }
-      });
-    }
+    checkExpiredAccesstoken().then((response) => {
+      if (response) {
+        const examBtn = document.getElementById("examBtn");
+        examBtn.setAttribute("disabled", true);
+        examBtn.innerText = "글등록 중...";
 
-    async function getUserInfo() {
-      try {
-        await api.get("/no-permit/api/user/info").then((response) => {
-          const examBtn = document.getElementById("examBtn");
-          examBtn.setAttribute("disabled", true);
-          examBtn.innerText = "글등록 중...";
+        let formData = new FormData();
 
-          let formData = new FormData();
+        formData.append("file", uploadfile[0]);
 
-          formData.append("file", uploadfile[0]);
+        formData.append(
+          "article",
+          new Blob([JSON.stringify(photo)], { type: "application/json" })
+        );
 
-          formData.append(
-            "article",
-            new Blob([JSON.stringify(photo)], { type: "application/json" })
-          );
-
-          api
-            .post(`/api/boards/${boardId}/articles`, formData)
-            .then((response) => {
-              if (response.data.success) {
-                Swal.fire({
-                  icon: "success",
-                  title: "게시글 작성을 성공했습니다.",
-                }).then((result) => {
-                  if (result.isConfirmed) {
-                    navigate("/project");
-                  }
-                });
-              } else {
-                Swal.fire({
-                  icon: "error",
-                  title: "게시글 작성을 실패했습니다.",
-                });
-              }
-            });
-        });
-      } catch (error) {
-        delCookie("SammaruAccessToken");
-        expiredLogin();
+        api
+          .post(`/api/boards/${boardId}/articles`, formData)
+          .then((response) => {
+            if (response.data.success) {
+              Swal.fire({
+                icon: "success",
+                title: "게시글 작성을 성공했습니다.",
+              }).then((result) => {
+                if (result.isConfirmed) {
+                  navigate("/project");
+                }
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "게시글 작성을 실패했습니다.",
+              });
+            }
+          });
       }
-    }
-    if (getCookie("SammaruAccessToken")) getUserInfo();
-    else expiredLogin();
+    });
   };
 
   const handlePostCancel = () => {


### PR DESCRIPTION
## 👀 이슈

resolve #179 

## 📌 개요

- 현재 홈페이지 내에서 accesstoken 만료 후 API를 호출하면
에러가 발생하는데, 사용자 입장에서는 별도의 안내 문구를 보여주지
않으면 왜 에러가 발생하였는지 인지하여 못 하기 때문에 해당 문제를 보안하기
위한 코드를 추가하였지만, 모듈화가 되어 있지 않아 API를 호출하는
모든 컴포넌트 내에서 해당 코드를 반복적으로 사용하여 불필요하게 코드 라인이
늘어나 refactoring을 염두에 두게 되었습니다.

## 👩‍💻 작업 사항

- accesstoken 만료 여부를 확인하고 처리하는 코드를 특정 파일 내에 정의하고 기존에
해당 코드를 사용하는 모든 컴포넌트 내에서 위 함수를 호출하는 방법으로 수정
- `회원관리` 컴포넌트 내 **`검색`** 버튼의 색이 다소 연하게 좀 더 진한 색으로 변경하였습니다.
- `회원관리` 컴포넌트 내 **`검색`** 버튼 클릭 시 API로부터 받아오는 값을 알맞은 형태로
받지 않고 있던 오류가 발견되어 알맞게 수정하였습니다.

## ✅ 참고 사항
- 결과 화면
![ezgif com-gif-maker (11)](https://user-images.githubusercontent.com/56868605/192556955-c82fb75f-c985-49bb-a1d4-6e5f279c23e3.gif)

![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/56868605/192558125-401f45f1-c636-40e1-a39c-1e4ae1f53246.gif)

- `검색 버튼` 색상 변경 전

![스크린샷 2022-10-02 오후 4 25 01](https://user-images.githubusercontent.com/56868605/193442967-7bac61ba-30f1-4710-a2c3-5ac4e5fc14df.png)

- `검색 버튼` 색상 변경 후
- 
![스크린샷 2022-10-02 오후 4 20 40](https://user-images.githubusercontent.com/56868605/193442977-88e7a703-38bf-44c1-9422-f53a5ed51a2e.png)