### PR TITLE
[fix]: 존재하지 않는 이메일로 임시 비밀번호 생성 API 사용 시 발생하는 에러에 대한 안내 문구 추가 (#184)

### DIFF
--- a/src/pages/findUser/FindUserPage.js
+++ b/src/pages/findUser/FindUserPage.js
@@ -1,67 +1,106 @@
-import { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import "./FindUserPage.scss"
-import Swal from "sweetalert2"
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./FindUserPage.scss";
+import Swal from "sweetalert2";
 import api from "../../utils/api";
 
 function FindUserPage() {
-    const [email, setEmail] = useState("")
-    const navigate = useNavigate()
+  const [email, setEmail] = useState("");
+  const navigate = useNavigate();
 
-
-    const onFindUser = (e)=>{
-        const findCheck = document.getElementById("findCheck");
-        findCheck.setAttribute('disabled', true);
-        findCheck.innerText = "확인 중..."
-        e.preventDefault();
-        api.post("/auth/tempPassword?userEmail="+email).then((response) => {
-            if(response.data.success){
-                Swal.fire({
-                    icon: 'success',
-                    title: '해당 이메일에 임시 비밀번호를 전송했습니다.',
-                })
-                    .then((result)=>{
-                        if(result.isConfirmed){
-                            navigate("/")
-                        }
-                    })
-            }
-            else{
-                Swal.fire({
-                    icon: 'error',
-                    title: '해당  회원은 존재하지 않습니다.',
-                }).then((result)=>{
-                    if(result){
-                        findCheck.removeAttribute('disabled');
-                        findCheck.innerText = "확인"
-                    }
-                })
-
-            }
+  const onFindUser = async (e) => {
+    e.preventDefault();
+    const findCheck = document.getElementById("findCheck");
+    findCheck.setAttribute("disabled", true);
+    findCheck.innerText = "확인 중...";
+    try {
+      await api
+        .post("/auth/tempPassword?userEmail=" + email)
+        .then((response) => {
+          if (response.data.success) {
+            Swal.fire({
+              icon: "success",
+              title: "해당 이메일에 임시 비밀번호를 전송했습니다.",
+            }).then((result) => {
+              if (result.isConfirmed) {
+                navigate("/");
+              }
+            });
+          } else {
+            Swal.fire({
+              icon: "error",
+              title: "해당 회원은 존재하지 않습니다.",
+            }).then((result) => {
+              if (result) {
+                findCheck.removeAttribute("disabled");
+                findCheck.innerText = "확인";
+              }
+            });
+          }
         });
+    } catch (error) {
+      if (error.response.status === 400) {
+        Swal.fire({
+          icon: "error",
+          title:
+            error.response.data.apiError.message.substring(
+              0,
+              error.response.data.apiError.message.indexOf("!")
+            ) + ".",
+        }).then((result) => {
+          if (result) {
+            findCheck.removeAttribute("disabled");
+            findCheck.innerText = "확인";
+          }
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "예기치 못 한 에러가 발생하였습니다.",
+        }).then((result) => {
+          findCheck.removeAttribute("disabled");
+          findCheck.innerText = "확인";
+        });
+      }
     }
+  };
 
-    return(
-        <div className="FindUserPage">
-            <h1>회원정보 찾기</h1>
-            <br/>
-            <form className="findForm" onSubmit={(e)=>{onFindUser(e)}}>
-                <figure className="loginLogo">
-                <img
-                    src="img/login_logo.png"
-                    alt="로그인 로고 이미지"
-                />
-                </figure>
-                <input type={"email"} value={email} autoComplete="off" placeholder="이메일" required onChange={(e)=>{setEmail(e.target.value)}}></input>
+  return (
+    <div className="FindUserPage">
+      <h1>회원정보 찾기</h1>
+      <br />
+      <form
+        className="findForm"
+        onSubmit={(e) => {
+          onFindUser(e);
+        }}
+      >
+        <figure className="loginLogo">
+          <img src="img/login_logo.png" alt="로그인 로고 이미지" />
+        </figure>
+        <input
+          type={"email"}
+          value={email}
+          autoComplete="off"
+          placeholder="이메일"
+          required
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+        ></input>
 
-                <div className="findConfirm">
-                    <button id="findCheck" type="submit">확인</button>
-                </div>
-            </form> 
-            <p><strong>Note</strong>: 회원가입 시 등록하신 이메일 주소를 입력해 주세요. 해당 이메일로 비밀번호 정보를 보내드립니다.</p>
-
+        <div className="findConfirm">
+          <button id="findCheck" type="submit">
+            확인
+          </button>
         </div>
-    )
+      </form>
+      <p>
+        <strong>Note</strong>: 회원가입 시 등록하신 이메일 주소를 입력해 주세요.
+        해당 이메일로 비밀번호 정보를 보내드립니다.
+      </p>
+    </div>
+  );
 }
 
-export default FindUserPage
+export default FindUserPage;


### PR DESCRIPTION
## 👀 이슈

resolve #184 

## 📌 개요

임시 비밀번호 생성 컴포넌트에서 DB에 등록되지 않은 이메일로 정보 조회 시도 시
발생하는 문제에 대하여 사용자에게 안내가 되도록 문구를 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- **`FindUserPage.js** 파일 내 예외처리 문장 추가

## ✅ 참고 사항
- 수정 전

![스크린샷 2022-10-02 오후 7 39 35](https://user-images.githubusercontent.com/56868605/193449969-a64d5c75-069d-475d-a338-f4186e701afe.png)

- 수정 후

(밑 사진은 존재하지 않는 이메일로  `확인` 버튼 클릭 시 나타나는 문구)
![스크린샷 2022-10-02 오후 7 35 43](https://user-images.githubusercontent.com/56868605/193449978-abb3f935-8821-456a-8d96-0aadf51d3c5c.png)

(밑 사진은 비회원인 상태에서 API 사용 시 발생하는 에러에 대한 문구인데, 원래 임시 비밀번호 생성 API의 경우에는 별도로 권한을 필요로 하지 않기 때문에 필요하지 않은 코드이지만, 현재 백엔드 코드 버전에서는 로그인된 상태에서만 해당 API가 사용 가능하기 때문에 예외 처리 코드를 별도로 추가해 준 상태입니다.)
![스크린샷 2022-10-02 오후 7 36 29](https://user-images.githubusercontent.com/56868605/193449983-940dfc6c-6a51-46d9-a5e7-e13498d22897.png)
