### PR TITLE
[fix]: 비회원 유저의 족보 게시판 내 게시글 열람 차단 조건식 추가 (#186)

### DIFF
--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -5,6 +5,7 @@ import Swal from "sweetalert2";
 import exam from "../../imgs/banner/exam.jpg";
 import { myRole } from "../../hooks/useAuth";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { getCookie } from "../../hooks/useCookie";
 
 function ExamPage() {
   const navigate = useNavigate();
@@ -15,6 +16,7 @@ function ExamPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
+    if (!getCookie("SammaruAccessToken")) return;
     getBoardList().then((response) => {
       if (response.data.success) {
         response.data.response.forEach((res) => {


### PR DESCRIPTION
## 👀 이슈

resolve #186 

## 📌 개요

비회원인 상태에서 족보 게시판 내 게시글이 확인되는
문제가 있었습니다.

## 👩‍💻 작업 사항

- **`ExamPage.js`** 파일 내에 액세스 토큰 여부에 따라
그 다음 코드가 처리되도록 조건식을 추가함.

## ✅ 참고 사항

- 해결 전

<img width="672" alt="스크린샷 2022-10-03 오후 8 14 19" src="https://user-images.githubusercontent.com/56868605/193565085-20cf2e5b-19c7-4983-9fde-c19a9e76bc26.png">

- 해결 후

<img width="656" alt="스크린샷 2022-10-03 오후 8 21 53" src="https://user-images.githubusercontent.com/56868605/193565172-8944b1fe-151b-4708-91fb-a2b159d68787.png">