### PR TITLE
[fix]: 비회원 족보 게시판 접근 차단 (#189)

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -67,7 +67,14 @@ function App() {
         <Routes>
           <Route path="/" element={<MainPage />} />
           <Route path="/awards" element={<AwardsPage />} />
-          <Route path="/exam" element={<ExamPage />} />
+          <Route
+            path="/exam"
+            element={
+              <AuthGuard>
+                <ExamPage />
+              </AuthGuard>
+            }
+          />
           <Route
             path="/exam/examUpdate"
             element={
@@ -295,7 +302,7 @@ function App() {
               </AuthGuard>
             }
           />
-        <Route path="*" element={<NotFound />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </Router>
       <Footer />

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -181,11 +181,13 @@ function Navigation() {
                   소규모 프로젝트
                 </a>
               </li>
-              <li>
-                <a href="/exam" style={{ color: "#878787" }}>
-                  족보
-                </a>
-              </li>
+              {loading ? (
+                <li>
+                  <a href="/exam" style={{ color: "#878787" }}>
+                    족보
+                  </a>
+                </li>
+              ) : null}
             </ul>
           </li>
           <li>

--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -5,7 +5,6 @@ import Swal from "sweetalert2";
 import exam from "../../imgs/banner/exam.jpg";
 import { myRole } from "../../hooks/useAuth";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
-import { getCookie } from "../../hooks/useCookie";
 
 function ExamPage() {
   const navigate = useNavigate();
@@ -16,7 +15,6 @@ function ExamPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    if (!getCookie("SammaruAccessToken")) return;
     getBoardList().then((response) => {
       if (response.data.success) {
         response.data.response.forEach((res) => {


### PR DESCRIPTION
## 👀 이슈

resolve #189 

## 📌 개요

비회원인 상태에서 족보 게시판에 접근이 가능한
문제가 있어서 해당 문제를 수정하였습니다.

## 👩‍💻 작업 사항

- **`Navigation.js`** , **`Router.js`** 파일** 내 접근 차단 코드 추가

## ✅ 참고 사항

- 수정 전

<img width="619" alt="스크린샷 2022-10-03 오후 8 52 36" src="https://user-images.githubusercontent.com/56868605/193571662-6a08a3b6-35a9-4695-9192-13a32524f846.png">

- 수정 후

<img width="625" alt="스크린샷 2022-10-03 오후 8 47 39" src="https://user-images.githubusercontent.com/56868605/193571689-c6c8e540-6418-4229-9928-77793da884c1.png">