### PR TITLE
[feat] 댓글 (수정 & 삭제) 요소 및 기능 추가 (#192)

### DIFF
--- a/src/components/Comment.scss
+++ b/src/components/Comment.scss
@@ -1,60 +1,122 @@
 #comment {
-    margin-top: 6%;
+  margin-top: 10%;
 
-    .textarea-frame {
-        width: 100%;
-        height: 150px;
-        background-color: rgb(248, 250, 252);
+  .textarea-frame {
+    width: 100%;
+    height: 150px;
+    background-color: rgb(248, 250, 252);
+    display: flex;
+    justify-content: right;
+    align-items: center;
+    border: solid 1px #f3f3f3;
+  }
+
+  .textarea-frame {
+    width: 100%;
+    height: 150px;
+    background-color: rgb(248, 250, 252);
+    display: flex;
+    justify-content: right;
+    align-items: center;
+    border: solid 1px #f3f3f3;
+  }
+
+  textarea {
+    width: 85%;
+    height: 70%;
+    padding: 1%;
+    resize: none;
+  }
+
+  textarea::placeholder {
+    font-size: 0.8em;
+  }
+
+  button {
+    font-size: 1.1em;
+    margin-left: 3%;
+    margin-right: 1%;
+    height: 25%;
+    width: 7.5%;
+  }
+
+  table {
+    margin-top: 3%;
+  }
+
+  tbody {
+    background-color: rgb(248, 250, 252);
+    .user {
+      .authorInfo {
+        span {
+          font-size: 0.5em;
+          &:first-child::after {
+            content: "|";
+            position: relative;
+            bottom: 1px;
+            color: lightgrey;
+            padding: 0 3px 0 1px;
+            margin: 0 0.75%;
+          }
+        }
+        .createDt {
+          color: #aaa;
+        }
+      }
+      .content {
+        height: fit-content;
+        max-height: 5rem;
+        word-break: break-all;
+        overflow: auto;
+      }
+
+      .commentControl {
+        float: right;
         display: flex;
-        justify-content: right;
-        align-items: center;
-        border: solid 1px #f3f3f3
+        font-size: 0.7em;
+        .modifyingComment {
+          width: 50px;
+          color: black !important;
+          background-color: transparent;
+          box-shadow: none;
+          font-weight: 300;
+        }
+        .modifyingComment:after {
+          content: "|";
+          position: absolute;
+          bottom: 1px;
+          color: lightgrey;
+          padding-left: 22%;
+        }
+        .deletingComment {
+          width: 50px;
+          color: black !important;
+          background-color: transparent;
+          box-shadow: none;
+          font-weight: 300;
+          margin-right: -10px;
+        }
+      }
     }
+  }
 
-    textarea {
-        width: 85%;
-        height: 70%;
-        padding: 1%;
-        resize: none;
-    }
+  .comment-tr {
+    padding: 10% 0;
+  }
 
-    textarea::placeholder {
-        font-size: 0.8em;
-    }
+  .content-tr {
+    border-top: none;
+  }
 
-    button {
-        font-size: 1.1em;
-        margin-left: 3%;
-        margin-right: 1%;
-        height: 25%;
-        width: 7.5%;
-    }
+  .empty-tr {
+    background-color: white;
+  }
 
-    table {
-        margin-top: 3%;
-    }
+  table tbody tr:first-child {
+    border-top: solid 1px #e5e5e5;
+  }
 
-    tbody {
-        background-color: rgb(248, 250, 252);
-    }
-
-    .comment-tr {
-        padding: 10% 0;
-    }
-
-    .content-tr {
-        border-top: none;
-    }
-
-    .empty-tr {
-        background-color: white;
-    }
-
-    table tbody tr:first-child {
-        border-top: solid 1px #e5e5e5
-    }
-
-    ul li:first-child {
-        margin: 0.75em 0 0.75em 0
-    }
+  ul li:first-child {
+    margin: 0.75em 0 0.75em 0;
+  }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #192 

## 📌 개요

현재 댓글 기능 중에는 작성만 가능하기 때문에 수정 및 삭제가
가능하도록 API를 적용하여 요소 및 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- **`Comment.js`** 및 **`Comment.scss`** 파일을 수정하여
댓글 수정 및 삭제 대한 기능을 수행할 수 있도록 함
 
## ✅ 참고 사항
- 추가 전

![스크린샷 2022-10-05 오후 7 25 05](https://user-images.githubusercontent.com/56868605/194039126-08d0a2d9-24c0-4dea-949a-8ff6064682c4.png)

- 추가 후(내용이 길어질 경우에 스크롤이 가능하도록 함)

<img width="985" alt="스크린샷 2022-10-16 오후 2 47 45" src="https://user-images.githubusercontent.com/56868605/196020431-e1ed60f4-1a16-4e22-bfed-218a46df6757.png">
<img width="989" alt="스크린샷 2022-10-16 오후 2 53 50" src="https://user-images.githubusercontent.com/56868605/196020456-c3ab702b-b5cf-4a9c-9b91-35f2f7406f61.png">
