### PR TITLE
[bug]: Accesstoken 만료 시 게시글 내에서 API 호출로 인해 발생하는 버그 수정 (#194)

### DIFF
--- a/src/hooks/boardServices.js
+++ b/src/hooks/boardServices.js
@@ -1,5 +1,6 @@
 import api from "../utils/api";
 import Swal from "sweetalert2";
+import { delCookie } from "./useCookie";
 
 export const getBoardList = async () => {
   try {
@@ -19,19 +20,19 @@ export const getArticleList = async (id, pageNum, postNum) => {
       `/no-permit/api/boards/${id}/pages/${pageNum}?pageSize=${postNum}`
     );
   } catch (error) {
-    console.error(error);
-    return Swal.fire({
-      icon: "error",
-      title: "공지사항 목록 가져오기를 실패했습니다.",
-    });
+    window.location.href = "/login";
   }
 };
 
-
 export const getBoards = async (location) => {
-    try {
-        return await api.get("/api/boards/" + location.state.boardId + "/articles/" + location.state.articleId);
-    } catch (error) {
-        console.error(error);
-    }
+  try {
+    return await api.get(
+      "/api/boards/" +
+        location.state.boardId +
+        "/articles/" +
+        location.state.articleId
+    );
+  } catch (error) {
+    window.location.href = "/login";
+  }
 };


### PR DESCRIPTION
## 👀 이슈

resolve #194 

## 📌 개요

게시글 열람 시 액세스 토큰 시간 만료 후 새로고침을 하면
API호출이 제한되는데, 이를 무시하고 호출이 이뤄지게 되면
버그가 발생하고  이에 대한 처리가 가능하도록 작업하였습니다.

## 👩‍💻 작업 사항

- **boardServices.js``** 파일 내 API 호출 시 액세스 토큰이
만료되어 있는 상태라면 자동으로 로그인 페이지로 이동되도록 함.

## ✅ 참고 사항

- 에러 사진

<img width="1122" alt="스크린샷 2022-10-16 오후 1 34 19" src="https://user-images.githubusercontent.com/56868605/196018310-e902af34-f7ed-4bc6-b094-2cf9f01d26a2.png">

- 게시글 내에서 액세스 토큰 만료 후 새로고침 시 로그인 페이지로 이동되도록 함

<img width="937" alt="스크린샷 2022-10-16 오후 3 18 39" src="https://user-images.githubusercontent.com/56868605/196021341-85a22d3a-b461-4a2d-8e5f-0433c7a2edd3.png">

