### PR TITLE
[bug]: Accesstoken 만료 후 로그아웃 버튼 클릭 시 발생하는 에러 제거 (#197)

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -46,8 +46,7 @@ export async function checkExpiredAccesstoken() {
   } else expiredLogin();
 }
 
-export function signout() {
-  api.delete("/auth/logout").then((response) => {
-    window.location.href = "/";
-  });
+export async function signout() {
+  delCookie("SammaruAccessToken");
+  window.location.href = "/";
 }


### PR DESCRIPTION
## 👀 이슈

resolve #197 

## 📌 개요

홈페이지 내에서 Accesstoken이 만료된 이후
로그아웃 버튼을 클릭하여 로그아웃 API 호출 시
이미 API 호출 권한이 없는 상태이기 때문에 발생
하는 에러를 제거하고자 하였습니다.

## 👩‍💻 작업 사항

- **`useAuth.js`** 컴포넌트 내 signout함수 내에서
기존의 `logout` API 호출 없이도 delCookie 함수를 이용하여
로그아웃 기능을 구현할 수 있었기에 해당 API 호출 코드를 delCookie
함수로 대체하여 버그를 제거하였습니다.

## ✅ 참고 사항

- 해결 후

![ezgif com-gif-maker (17)](https://user-images.githubusercontent.com/56868605/198869366-4efba21f-1e7c-42e3-ab03-33a9364bb9ff.gif)