### PR TITLE
[feat]: 메인 페이지 공지사항 내 "더 보기" 요소 추가 (#198)

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2200,6 +2200,10 @@ button.alt:active,
   margin-top: 1.25em;
 }
 
+#features > .noticeClicked {
+  padding-bottom: 12em;
+}
+
 /* Banner */
 
 #banner {

--- a/src/pages/main/Board.js
+++ b/src/pages/main/Board.js
@@ -87,6 +87,7 @@ function Board() {
           </tbody>
         ) : null}
       </table>
+      <button onClick={() => navigate("./notice")}>더 보기</button>
     </div>
   );
 }

--- a/src/pages/main/MainPage.js
+++ b/src/pages/main/MainPage.js
@@ -6,20 +6,22 @@ import ClubAwards from "./ClubAwards";
 import "./MainPage.scss";
 import logo from "../../imgs/logo.png";
 import sammaru from "../../imgs/sammaru.png";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 function MainPage() {
   const tab = useRef([]);
+  const [containerClassName, setContainerClassName] = useState("container");
 
   function openTab(tabName) {
     var i;
-
     for (i = 0; i < tab.current.length; i++) {
       tab.current[i].style.display = "none";
     }
     if (tabName === "scheduletab") {
+      setContainerClassName("container");
       tab.current[0].style.display = "block";
     } else if (tabName === "noticetab") {
+      setContainerClassName("noticeClicked");
       tab.current[1].style.display = "block";
     }
   }
@@ -64,9 +66,8 @@ function MainPage() {
 
           <section id="features">
             <div
-              className="container"
+              className={containerClassName}
               style={{
-                padding: "0 0 5rem 0",
                 borderBottom: "solid 2px #e5e5e5",
                 boxShadow:
                   "inset 0px -8px 0px 0px #fff, inset 0px -10px 0px 0px #e5e5e5",


### PR DESCRIPTION
## 👀 이슈

resolve #198 

## 📌 개요

기존 메인페이지 내에 위치한 공지사항 게시판에는
화면 높이 내에 표시되는 게시글들만 확인할 수 있었기에
추가로 등록되어 있는 글들을 열람할 수 있도록 `더 보기`
버튼을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `더 보기` 버튼 클릭 시 공지사항 게시판 컴포넌트로 이동할 수
있도록 코드를 추가하였습니다.

## ✅ 참고 사항

- 추가 후(GIF 파일이 업로드 되어 있어 불러오는 데 시간이 다소 소요될 수 있습니다)

![ezgif com-gif-maker (18)](https://user-images.githubusercontent.com/56868605/198874993-c17cf99c-2734-4584-8f01-0d2b68f32003.gif)