### PR TITLE
[bug]: 게시글 내용 확인 시 이스케이프 시퀀스 처리가 되지 않았던 문제 수정 (#210)

### DIFF
--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -40,7 +40,7 @@ function ExamDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -40,7 +40,7 @@ function FreeBoardDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -40,7 +40,7 @@ function NoticeDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/photo/PhotoDetail.js
+++ b/src/pages/photo/PhotoDetail.js
@@ -117,7 +117,7 @@ const PhotoDetail = () => {
           </div>
           <hr />
 
-          <p>{article.content}</p>
+          <pre>{article.content}</pre>
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -41,7 +41,7 @@ function ReportDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -40,7 +40,7 @@ function SeminarDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -40,7 +40,7 @@ function ProjectDetailPage() {
           </div>
 
           <div className="contents">
-            {article.content}
+            <pre>{article.content}</pre>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"


### PR DESCRIPTION
## 👀 이슈

resolve #210 

## 📌 개요

게시글 작성 시 개행을 포함한 이스케이프 시퀀스가 열람 시
적용되지 않고 표시되는 문제점이 발견되어 수정이 필요하였습니다.

## 👩‍💻 작업 사항

- 모든 게시글 디테일 컴포넌트 내에서 게시글의 내용을 표시하는
부분은 **`pre`** 태그로 감싸 이스케이프 시퀀스가 적용될 수
있도록 하였습니다.

## ✅ 참고 사항

- 수정 후

https://user-images.githubusercontent.com/56868605/200549315-c6c09125-ecab-47b3-9a4e-8ea4ace51926.mov