### PR TITLE
[feat]: 비회원 유저의 게시판 접근 시 내부 게시글 열람 및 접근 제한 기능 추가 (#217)

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -67,14 +67,7 @@ function App() {
         <Routes>
           <Route path="/" element={<MainPage />} />
           <Route path="/awards" element={<AwardsPage />} />
-          <Route
-            path="/exam"
-            element={
-              <AuthGuard>
-                <ExamPage />
-              </AuthGuard>
-            }
-          />
+          <Route path="/exam" element={<ExamPage />} />
           <Route
             path="/exam/examUpdate"
             element={

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,24 +2,37 @@ import api from "../utils/api";
 import Swal from "sweetalert2";
 import { delCookie, getCookie } from "./useCookie";
 
-export function myRole() {
-  return api.get("/no-permit/api/user/info").then((response) => {
-    if (!response) {
-      return "not authorized";
-    } else if (response.data.response.role === "ROLE_TEMP") {
-      return "temp";
-    } else if (response.data.response.role === "ROLE_MEMBER") {
-      return "member";
-    } else if (response.data.response.role === "ROLE_ADMIN") {
-      return "admin";
-    }
-  });
+export async function myRole() {
+  try {
+    return await api.get("/no-permit/api/user/info").then((response) => {
+      if (!response) {
+        return "not authorized";
+      } else if (response.data.response.role === "ROLE_TEMP") {
+        return "temp";
+      } else if (response.data.response.role === "ROLE_MEMBER") {
+        return "member";
+      } else if (response.data.response.role === "ROLE_ADMIN") {
+        return "admin";
+      }
+    });
+  } catch (error) {
+    Swal.fire({
+      title: "로그인이 필요한 서비스입니다.",
+      text: "자동으로 로그인 페이지로 이동합니다.",
+      icon: "warning",
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "확인",
+    }).then((result) => {
+      window.location.href = "/login";
+    });
+  }
 }
 
 export async function checkExpiredAccesstoken() {
   function expiredLogin() {
     Swal.fire({
-      title: "로그인 상태 허용 시간이 초과되었습니다.",
+      title: "로그인 상태 허용\n시간이 초과되었습니다.",
       text: "로그인 페이지로 다시 이동하시겠습니까?",
       icon: "error",
       showCancelButton: true,

--- a/src/pages/exam/ExamPage.js
+++ b/src/pages/exam/ExamPage.js
@@ -3,8 +3,8 @@ import { Pagination } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
 import exam from "../../imgs/banner/exam.jpg";
-import { myRole } from "../../hooks/useAuth";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 function ExamPage() {
   const navigate = useNavigate();
@@ -15,14 +15,19 @@ function ExamPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "족보") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "족보") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });

--- a/src/pages/freeBoard/FreeBoardPage.js
+++ b/src/pages/freeBoard/FreeBoardPage.js
@@ -3,6 +3,7 @@ import { Pagination } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import free from "../../imgs/banner/free.jpg";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 function FreeBoardPage() {
   const navigate = useNavigate();
@@ -13,14 +14,19 @@ function FreeBoardPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "자유게시판") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "자유게시판") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -17,7 +17,7 @@ function NoticePage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined)
+      if (response != undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -31,6 +31,7 @@ function NoticePage() {
             });
           }
         });
+      }
     });
 
     if (pageNum % 10 === 1) setPageList(pageNum);

--- a/src/pages/notice/NoticePage.js
+++ b/src/pages/notice/NoticePage.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import notice from "../../imgs/banner/notice.jpg";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 function NoticePage() {
   const navigate = useNavigate();
@@ -14,18 +15,22 @@ function NoticePage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "공지사항") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined)
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "공지사항") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });
-      }
     });
 
     if (pageNum % 10 === 1) setPageList(pageNum);

--- a/src/pages/photo/PhotoList.js
+++ b/src/pages/photo/PhotoList.js
@@ -3,6 +3,7 @@ import { Row, Col, Pagination } from "react-bootstrap";
 import "./PhotoList.scss";
 import { useNavigate } from "react-router-dom";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 const PhotoList = () => {
   const navigate = useNavigate();
@@ -13,14 +14,19 @@ const PhotoList = () => {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "사진첩") {
-            setBoardid(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setPhotoList(res.data.response);
-              setloading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "사진첩") {
+                setBoardid(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setPhotoList(res.data.response);
+                  setloading(true);
+                });
+              }
             });
           }
         });

--- a/src/pages/report/ReportPage.js
+++ b/src/pages/report/ReportPage.js
@@ -3,6 +3,7 @@ import { Pagination } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import report from "../../imgs/banner/report.jpg";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 function ReportPage() {
   const navigate = useNavigate();
@@ -13,14 +14,19 @@ function ReportPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "활동보고서") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "활동보고서") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });
@@ -51,13 +57,13 @@ function ReportPage() {
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(
-          <Pagination.Item
-              active={pageNum === pageList + k}
-              key={k}
-              onClick={() => setPageNum(pageList + k)}
-          >
-            {pageList + k}
-          </Pagination.Item>
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
       );
       if (pageList + k === boardList.totalPages) break;
     }
@@ -87,103 +93,103 @@ function ReportPage() {
   };
 
   return (
-      <div className="noticePage">
-        <div className="container">
-          <img
-              src={report}
-              alt="활동보고서 배너"
-              // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
-              style={{ width: "100%", height: "auto" }}
-          ></img>
-          <div className="location">
-            <img className="home" src="home.png" alt="home"></img>
-            <span>{" /  "}</span>
-            <span>{"   자료실"}</span>
-            <span>{" /  "}</span>
-            <span> 활동 보고서 </span>
-          </div>
-          <div className="search">
-            <div className="inp_sch">
-              <b> 검색구분 </b>
-              <select name="srchTp">
-                <option value="title" style={{ textAlign: "center" }}>
-                  제목
-                </option>
-                <option value="cpntent" style={{ textAlign: "center" }}>
-                  내용
-                </option>
-                <option value="both" style={{ textAlign: "center" }}>
-                  제목+내용
-                </option>
-              </select>
-              <input type="text"></input>
-              <input type="submit" value={"검색"}></input>
-            </div>
-          </div>
-
-          <div
-              className="adminPost"
-              style={{
-                display: "flex",
-                justifyContent: "right",
-                margin: "10px 0px 20px 0px",
-              }}
-          >
-            <button
-                className="w3-bar-item w3-button"
-                style={{
-                  background: "#6a81ed",
-                  width: "130px",
-                  padding: "10px 0px 10px 0px",
-                }}
-                onClick={reportUpload}
-            >
-              작성하기
-            </button>
-          </div>
-
-          <div className="contents">
-            <div className="contentsTitle">
-              <div className="num">번호</div>
-              <div className="value">제목</div>
-              <div className="date">작성일</div>
-            </div>
-            {loading ? (
-                <>
-                  {boardList.content.map((list, i) => {
-                    let createDt = list.createDt.slice(0, 10);
-                    return (
-                        <div key={i} className="eachContents">
-                          <div
-                              className="content"
-                              onClick={() => {
-                                onClickDetail(list);
-                              }}
-                          >
-                            <div className="num">{list.id}</div>
-                            <div className="value">{list.title}</div>
-                            <div className="date" style={{ textAlign: "center" }}>
-                              {createDt}
-                            </div>
-                          </div>
-                        </div>
-                    );
-                  })}
-                </>
-            ) : null}
+    <div className="noticePage">
+      <div className="container">
+        <img
+          src={report}
+          alt="활동보고서 배너"
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
+        ></img>
+        <div className="location">
+          <img className="home" src="home.png" alt="home"></img>
+          <span>{" /  "}</span>
+          <span>{"   자료실"}</span>
+          <span>{" /  "}</span>
+          <span> 활동 보고서 </span>
+        </div>
+        <div className="search">
+          <div className="inp_sch">
+            <b> 검색구분 </b>
+            <select name="srchTp">
+              <option value="title" style={{ textAlign: "center" }}>
+                제목
+              </option>
+              <option value="cpntent" style={{ textAlign: "center" }}>
+                내용
+              </option>
+              <option value="both" style={{ textAlign: "center" }}>
+                제목+내용
+              </option>
+            </select>
+            <input type="text"></input>
+            <input type="submit" value={"검색"}></input>
           </div>
         </div>
 
-        <div className="pageNum">
-          <Pagination>
-            <Pagination.First onClick={() => onChangingPage("first")} />
-            <Pagination.Prev onClick={() => onChangingPage("prev")} />
-            {addingPaginationItem()}
-            <Pagination.Next onClick={() => onChangingPage("next")} />
-            <Pagination.Last onClick={() => onChangingPage("last")} />
-          </Pagination>
+        <div
+          className="adminPost"
+          style={{
+            display: "flex",
+            justifyContent: "right",
+            margin: "10px 0px 20px 0px",
+          }}
+        >
+          <button
+            className="w3-bar-item w3-button"
+            style={{
+              background: "#6a81ed",
+              width: "130px",
+              padding: "10px 0px 10px 0px",
+            }}
+            onClick={reportUpload}
+          >
+            작성하기
+          </button>
+        </div>
+
+        <div className="contents">
+          <div className="contentsTitle">
+            <div className="num">번호</div>
+            <div className="value">제목</div>
+            <div className="date">작성일</div>
+          </div>
+          {loading ? (
+            <>
+              {boardList.content.map((list, i) => {
+                let createDt = list.createDt.slice(0, 10);
+                return (
+                  <div key={i} className="eachContents">
+                    <div
+                      className="content"
+                      onClick={() => {
+                        onClickDetail(list);
+                      }}
+                    >
+                      <div className="num">{list.id}</div>
+                      <div className="value">{list.title}</div>
+                      <div className="date" style={{ textAlign: "center" }}>
+                        {createDt}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </>
+          ) : null}
         </div>
       </div>
+
+      <div className="pageNum">
+        <Pagination>
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
+        </Pagination>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/seminar/SeminarPage.js
+++ b/src/pages/seminar/SeminarPage.js
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import seminar from "../../imgs/banner/seminar.jpg";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
+import { myRole } from "../../hooks/useAuth";
 
 function SeminarPage() {
   const navigate = useNavigate();
@@ -14,14 +15,19 @@ function SeminarPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "특강자료") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "특강자료") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });
@@ -52,13 +58,13 @@ function SeminarPage() {
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(
-          <Pagination.Item
-              active={pageNum === pageList + k}
-              key={k}
-              onClick={() => setPageNum(pageList + k)}
-          >
-            {pageList + k}
-          </Pagination.Item>
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
       );
       if (pageList + k === boardList.totalPages) break;
     }
@@ -88,103 +94,103 @@ function SeminarPage() {
   };
 
   return (
-      <div className="noticePage">
-        <div className="container">
-          <img
-              src={seminar}
-              alt="세미나 배너"
-              // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
-              style={{ width: "100%", height: "auto" }}
-          ></img>
-          <div className="location">
-            <img className="home" src="home.png" alt="home"></img>
-            <span>{" /  "}</span>
-            <span>{"   자료실"}</span>
-            <span>{" /  "}</span>
-            <span> 특강 자료 </span>
-          </div>
-          <div className="search">
-            <div className="inp_sch">
-              <b> 검색구분 </b>
-              <select name="srchTp">
-                <option value="title" style={{ textAlign: "center" }}>
-                  제목
-                </option>
-                <option value="cpntent" style={{ textAlign: "center" }}>
-                  내용
-                </option>
-                <option value="both" style={{ textAlign: "center" }}>
-                  제목+내용
-                </option>
-              </select>
-              <input type="text"></input>
-              <input type="submit" value={"검색"}></input>
-            </div>
-          </div>
-
-          <div
-              className="adminPost"
-              style={{
-                display: "flex",
-                justifyContent: "right",
-                margin: "10px 0px 20px 0px",
-              }}
-          >
-            <button
-                className="w3-bar-item w3-button"
-                style={{
-                  background: "#6a81ed",
-                  width: "130px",
-                  padding: "10px 0px 10px 0px",
-                }}
-                onClick={seminarUpload}
-            >
-              작성하기
-            </button>
-          </div>
-
-          <div className="contents">
-            <div className="contentsTitle">
-              <div className="num">번호</div>
-              <div className="value">제목</div>
-              <div className="date">작성일</div>
-            </div>
-            {loading ? (
-                <>
-                  {boardList.content.map((list, i) => {
-                    let createDt = list.createDt.slice(0, 10);
-                    return (
-                        <div key={i} className="eachContents">
-                          <div
-                              className="content"
-                              onClick={() => {
-                                onClickDetail(list);
-                              }}
-                          >
-                            <div className="num">{list.id}</div>
-                            <div className="value">{list.title}</div>
-                            <div className="date" style={{ textAlign: "center" }}>
-                              {createDt}
-                            </div>
-                          </div>
-                        </div>
-                    );
-                  })}
-                </>
-            ) : null}
+    <div className="noticePage">
+      <div className="container">
+        <img
+          src={seminar}
+          alt="세미나 배너"
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
+        ></img>
+        <div className="location">
+          <img className="home" src="home.png" alt="home"></img>
+          <span>{" /  "}</span>
+          <span>{"   자료실"}</span>
+          <span>{" /  "}</span>
+          <span> 특강 자료 </span>
+        </div>
+        <div className="search">
+          <div className="inp_sch">
+            <b> 검색구분 </b>
+            <select name="srchTp">
+              <option value="title" style={{ textAlign: "center" }}>
+                제목
+              </option>
+              <option value="cpntent" style={{ textAlign: "center" }}>
+                내용
+              </option>
+              <option value="both" style={{ textAlign: "center" }}>
+                제목+내용
+              </option>
+            </select>
+            <input type="text"></input>
+            <input type="submit" value={"검색"}></input>
           </div>
         </div>
 
-        <div className="pageNum">
-          <Pagination>
-            <Pagination.First onClick={() => onChangingPage("first")} />
-            <Pagination.Prev onClick={() => onChangingPage("prev")} />
-            {addingPaginationItem()}
-            <Pagination.Next onClick={() => onChangingPage("next")} />
-            <Pagination.Last onClick={() => onChangingPage("last")} />
-          </Pagination>
+        <div
+          className="adminPost"
+          style={{
+            display: "flex",
+            justifyContent: "right",
+            margin: "10px 0px 20px 0px",
+          }}
+        >
+          <button
+            className="w3-bar-item w3-button"
+            style={{
+              background: "#6a81ed",
+              width: "130px",
+              padding: "10px 0px 10px 0px",
+            }}
+            onClick={seminarUpload}
+          >
+            작성하기
+          </button>
+        </div>
+
+        <div className="contents">
+          <div className="contentsTitle">
+            <div className="num">번호</div>
+            <div className="value">제목</div>
+            <div className="date">작성일</div>
+          </div>
+          {loading ? (
+            <>
+              {boardList.content.map((list, i) => {
+                let createDt = list.createDt.slice(0, 10);
+                return (
+                  <div key={i} className="eachContents">
+                    <div
+                      className="content"
+                      onClick={() => {
+                        onClickDetail(list);
+                      }}
+                    >
+                      <div className="num">{list.id}</div>
+                      <div className="value">{list.title}</div>
+                      <div className="date" style={{ textAlign: "center" }}>
+                        {createDt}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </>
+          ) : null}
         </div>
       </div>
+
+      <div className="pageNum">
+        <Pagination>
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
+        </Pagination>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/subProject/ProjectPage.js
+++ b/src/pages/subProject/ProjectPage.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
-import Swal from "sweetalert2";
 import project from "../../imgs/banner/project.jpg";
 import { myRole } from "../../hooks/useAuth";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
@@ -15,14 +14,19 @@ function ProjectPage() {
   const [pageList, setPageList] = useState(1);
 
   useEffect(() => {
-    getBoardList().then((response) => {
-      if (response.data.success) {
-        response.data.response.forEach((res) => {
-          if (res.name === "소규모프로젝트") {
-            setBoardId(res.id);
-            getArticleList(res.id, pageNum, 10).then((res) => {
-              setBoardList(res.data.response);
-              setLoading(true);
+    // 비회원의 권한 확인
+    myRole().then((response) => {
+      if (response != undefined) {
+        getBoardList().then((response) => {
+          if (response.data.success) {
+            response.data.response.forEach((res) => {
+              if (res.name === "소규모프로젝트") {
+                setBoardId(res.id);
+                getArticleList(res.id, pageNum, 10).then((res) => {
+                  setBoardList(res.data.response);
+                  setLoading(true);
+                });
+              }
             });
           }
         });
@@ -53,13 +57,13 @@ function ProjectPage() {
     const result = [];
     for (let k = 0; k < 10; k++) {
       result.push(
-          <Pagination.Item
-              active={pageNum === pageList + k}
-              key={k}
-              onClick={() => setPageNum(pageList + k)}
-          >
-            {pageList + k}
-          </Pagination.Item>
+        <Pagination.Item
+          active={pageNum === pageList + k}
+          key={k}
+          onClick={() => setPageNum(pageList + k)}
+        >
+          {pageList + k}
+        </Pagination.Item>
       );
       if (pageList + k === boardList.totalPages) break;
     }
@@ -89,103 +93,103 @@ function ProjectPage() {
   };
 
   return (
-      <div className="noticePage">
-        <div className="container">
-          <img
-              src={project}
-              alt="소규모프로젝트 배너"
-              // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
-              style={{ width: "100%", height: "auto" }}
-          ></img>
-          <div className="location">
-            <img className="home" src="home.png" alt="home"></img>
-            <span>{" /  "}</span>
-            <span>{"   자료실"}</span>
-            <span>{" /  "}</span>
-            <span> 소규모 프로젝트 </span>
-          </div>
-          <div className="search">
-            <div className="inp_sch">
-              <b> 검색구분 </b>
-              <select name="srchTp">
-                <option value="title" style={{ textAlign: "center" }}>
-                  제목
-                </option>
-                <option value="cpntent" style={{ textAlign: "center" }}>
-                  내용
-                </option>
-                <option value="both" style={{ textAlign: "center" }}>
-                  제목+내용
-                </option>
-              </select>
-              <input type="text"></input>
-              <input type="submit" value={"검색"}></input>
-            </div>
-          </div>
-
-          <div
-              className="adminPost"
-              style={{
-                display: "flex",
-                justifyContent: "right",
-                margin: "10px 0px 20px 0px",
-              }}
-          >
-            <button
-                className="w3-bar-item w3-button"
-                style={{
-                  background: "#6a81ed",
-                  width: "130px",
-                  padding: "10px 0px 10px 0px",
-                }}
-                onClick={examUpload}
-            >
-              작성하기
-            </button>
-          </div>
-
-          <div className="contents">
-            <div className="contentsTitle">
-              <div className="num">번호</div>
-              <div className="value">제목</div>
-              <div className="date">작성일</div>
-            </div>
-            {loading ? (
-                <>
-                  {boardList.content.map((list, i) => {
-                    let createDt = list.createDt.slice(0, 10);
-                    return (
-                        <div key={i} className="eachContents">
-                          <div
-                              className="content"
-                              onClick={() => {
-                                onClickDetail(list);
-                              }}
-                          >
-                            <div className="num">{list.id}</div>
-                            <div className="value">{list.title}</div>
-                            <div className="date" style={{ textAlign: "center" }}>
-                              {createDt}
-                            </div>
-                          </div>
-                        </div>
-                    );
-                  })}
-                </>
-            ) : null}
+    <div className="noticePage">
+      <div className="container">
+        <img
+          src={project}
+          alt="소규모프로젝트 배너"
+          // height값을 auto로 변경하여 브라우저의 크기가 변경되어도 이미지 비율 유지
+          style={{ width: "100%", height: "auto" }}
+        ></img>
+        <div className="location">
+          <img className="home" src="home.png" alt="home"></img>
+          <span>{" /  "}</span>
+          <span>{"   자료실"}</span>
+          <span>{" /  "}</span>
+          <span> 소규모 프로젝트 </span>
+        </div>
+        <div className="search">
+          <div className="inp_sch">
+            <b> 검색구분 </b>
+            <select name="srchTp">
+              <option value="title" style={{ textAlign: "center" }}>
+                제목
+              </option>
+              <option value="cpntent" style={{ textAlign: "center" }}>
+                내용
+              </option>
+              <option value="both" style={{ textAlign: "center" }}>
+                제목+내용
+              </option>
+            </select>
+            <input type="text"></input>
+            <input type="submit" value={"검색"}></input>
           </div>
         </div>
 
-        <div className="pageNum">
-          <Pagination>
-            <Pagination.First onClick={() => onChangingPage("first")} />
-            <Pagination.Prev onClick={() => onChangingPage("prev")} />
-            {addingPaginationItem()}
-            <Pagination.Next onClick={() => onChangingPage("next")} />
-            <Pagination.Last onClick={() => onChangingPage("last")} />
-          </Pagination>
+        <div
+          className="adminPost"
+          style={{
+            display: "flex",
+            justifyContent: "right",
+            margin: "10px 0px 20px 0px",
+          }}
+        >
+          <button
+            className="w3-bar-item w3-button"
+            style={{
+              background: "#6a81ed",
+              width: "130px",
+              padding: "10px 0px 10px 0px",
+            }}
+            onClick={examUpload}
+          >
+            작성하기
+          </button>
+        </div>
+
+        <div className="contents">
+          <div className="contentsTitle">
+            <div className="num">번호</div>
+            <div className="value">제목</div>
+            <div className="date">작성일</div>
+          </div>
+          {loading ? (
+            <>
+              {boardList.content.map((list, i) => {
+                let createDt = list.createDt.slice(0, 10);
+                return (
+                  <div key={i} className="eachContents">
+                    <div
+                      className="content"
+                      onClick={() => {
+                        onClickDetail(list);
+                      }}
+                    >
+                      <div className="num">{list.id}</div>
+                      <div className="value">{list.title}</div>
+                      <div className="date" style={{ textAlign: "center" }}>
+                        {createDt}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </>
+          ) : null}
         </div>
       </div>
+
+      <div className="pageNum">
+        <Pagination>
+          <Pagination.First onClick={() => onChangingPage("first")} />
+          <Pagination.Prev onClick={() => onChangingPage("prev")} />
+          {addingPaginationItem()}
+          <Pagination.Next onClick={() => onChangingPage("next")} />
+          <Pagination.Last onClick={() => onChangingPage("last")} />
+        </Pagination>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 👀 이슈

resolve #217 

## 📌 개요

현재 로그인이 되어 있지 않은 사용자의 경우 홈페이지 내 게시판 접근 시
정상적으로 접근이 가능하고, 게시글 목록 조회가 가능하였는데, 이 부분에
대하여 제한을 둘 수 있도록 작업하였습니다.

## 👩‍💻 작업 사항

- 비회원의 게시판 접근 시 이를 제한하고, 로그인 페이지로 이동될 수 있도록 합니다.

## ✅ 참고 사항

- 작업 이전의 상황

https://user-images.githubusercontent.com/56868605/204612183-a2759343-a5fd-4f5b-9550-5add35aab4d2.mov

- 작업 이후

https://user-images.githubusercontent.com/56868605/204612449-a360006f-c21c-4b11-bfa2-c183fef127af.mov