### PR TITLE
[feat]: 관리자 페이지의 회원 관리 탭 내부 테이블 내에 (회원 추방 기능) 추가 (#219)

### DIFF
--- a/src/pages/management/MemberManage.js
+++ b/src/pages/management/MemberManage.js
@@ -96,6 +96,50 @@ function MemberManage() {
     });
   };
 
+  /**
+   * 회원 목록에서 특정 회원을 제거하는 함수
+   * @param {*} username
+   * @param {*} id
+   */
+  const userRemoveHandler = (username, id) => {
+    checkExpiredAccesstoken().then((response) => {
+      Swal.fire({
+        icon: "info",
+        title: `${username} 사용자를 회원\n목록에서 제거하시겠습니까?`,
+        showDenyButton: true,
+        confirmButtonText: "네",
+        denyButtonText: `아니요`,
+      }).then(async (response) => {
+        if (response.isConfirmed) {
+          try {
+            await api.delete("/api/users/" + id).then((result) => {
+              searchAllUsers();
+              Swal.fire({
+                icon: "info",
+                title: `${username} 사용자를\n 정상적으로 제거하였습니다.`,
+              });
+            });
+          } catch (error) {
+            if (error.response.status === 406) {
+              Swal.fire({
+                icon: "error",
+                title: `관리자 권한을 지닌\n사용자는 제거할 수 없습니다.`,
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "예기치 못 한 에러가 발생하였습니다.",
+              });
+              window.location.href = "/login";
+            }
+          }
+        } else {
+          return;
+        }
+      });
+    });
+  };
+
   return (
     <div id="MemberManage">
       <form className="d-flex align-items-center">
@@ -128,6 +172,7 @@ function MemberManage() {
               <th>학번</th>
               <th>이메일</th>
               <th>회원권한</th>
+              <th>회원제거</th>
             </tr>
           </thead>
 
@@ -155,6 +200,16 @@ function MemberManage() {
                       <option value="ROLE_MEMBER">회원</option>
                       <option value="ROLE_ADMIN">관리자</option>
                     </select>
+                  </td>
+                  <td>
+                    <button
+                      className="text-bg-danger"
+                      onClick={(response) => {
+                        userRemoveHandler(member.username, member.userId);
+                      }}
+                    >
+                      추방
+                    </button>
                   </td>
                 </tr>
               );

--- a/src/pages/management/MemberManage.scss
+++ b/src/pages/management/MemberManage.scss
@@ -1,38 +1,48 @@
-#MemberManage{
-    margin: 0 5%;
-    margin-right: 20%;
-    input{
-        margin-top: 2%;
-        width: 20%;
-        margin-right: 2%;
-        font-size: 1.2em;
-    }
+#MemberManage {
+  margin: 0 5%;
+  margin-right: 20%;
+  input {
+    margin-top: 2%;
+    width: 20%;
+    margin-right: 2%;
+    font-size: 1.2em;
+  }
 
-    input::placeholder{
-        padding-left: 2%;
-    }
+  input::placeholder {
+    padding-left: 2%;
+  }
 
-    button{
-        width: 5%;
-        font-size: 1.2em;
-        background-color: #D3CFFF;
-        border-color: #D3CFFF;
-    }
+  button {
+    width: 5%;
+    font-size: 1.2em;
+    background-color: #d3cfff;
+    border-color: #d3cfff;
+  }
 
-    table{
-        width: 100%;
-        
-        margin-top: 1%;
+  table {
+    width: 100%;
 
-        border: 1px solid black;
-        text-align: center;
+    margin-top: 1%;
+
+    border: 1px solid black;
+    text-align: center;
+  }
+  th,
+  tr,
+  td {
+    border: 1px solid black;
+    font-size: 1.2em;
+    & > button {
+      border-radius: 5px;
+      box-shadow: none;
+      padding: 0;
+      font-size: 1.1rem;
+      width: 5rem;
+      height: 1.8rem;
     }
-    th, tr, td{
-        border: 1px solid black;
-        font-size: 1.2em;
-    }
-    th{
-        font-size: 1.5em;
-        font-weight: bold;
-    }
+  }
+  th {
+    font-size: 1.5em;
+    font-weight: bold;
+  }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #219 

## 📌 개요

현재 홈페이지 내에서 사용자가 회원가입을 완료하였을 때 회원 목록에
자동적으로 등록되는데, 올바르지 않은 회원에 대하여 추방을 진행할 수
있는 기능을 수행하고자 해당 작업에 필요한 요소 추가였습니다.


## 👩‍💻 작업 사항

- **`MemberManage.js`** 컴포넌트 내 `회원제거` 칼럼 추가 및
각 행 별 `추방` 버튼 요소 추가
- 추방 버튼 클릭 시 예외처리 및 회원 삭제 기능을 수행

## ✅ 참고 사항

- 작업 후

https://user-images.githubusercontent.com/56868605/205456942-9bef464b-4426-4035-87ac-cfd5bfe365f5.mov
