### PR TITLE
[fix]: WELCOME TO SAMMARU 클릭 시 '동아리 소개' 페이지로 이동되도록 기능 수정 (#221)

### DIFF
--- a/src/pages/main/MainPage.js
+++ b/src/pages/main/MainPage.js
@@ -6,6 +6,7 @@ import "./MainPage.scss";
 import logo from "../../imgs/logo.png";
 import sammaru from "../../imgs/sammaru.png";
 import { useRef, useState } from "react";
+import { Link } from "react-router-dom";
 
 function MainPage() {
   const tab = useRef([]);
@@ -43,7 +44,7 @@ function MainPage() {
                 }}
               />
               <h1 id="logo">
-                <a href="index.html" style={{ position: "relative" }}>
+                <Link to="clubIntro" style={{ position: "relative" }}>
                   WELCOME TO &nbsp;&nbsp;&nbsp;&nbsp;
                   <img
                     src={logo}
@@ -58,7 +59,7 @@ function MainPage() {
                     }}
                   />
                   &nbsp;SAMMaru
-                </a>
+                </Link>
               </h1>
             </div>
           </section>


### PR DESCRIPTION
## 👀 이슈

resolve #221 

## 📌 개요

현재 메인페이지 컴포넌트 상단에 위치한 `WELCOME TO SAMMARU` 텍스트
클릭 시 `https://sammaru.cbnu.ac.kr/index.html`로 이동되는 기능이 적용되어있어
`동아리 소개` 컴포넌트를 불러올 수 있도록 코드를 수정하였습니다.

## 👩‍💻 작업 사항

- **`MainPage.js`** 컴포넌트 내 a 태그를 Link 태그로 변경
- url을 `https://sammaru.cbnu.ac.kr/clubIntro`가 되도록 코드 수정

## ✅ 참고 사항

- 기능 수정 전

![ezgif com-gif-maker (19)](https://user-images.githubusercontent.com/56868605/205526733-327716f0-2194-4027-b8f9-04af1cfc5cae.gif)

- 기능 수정 후

![ezgif com-gif-maker (20)](https://user-images.githubusercontent.com/56868605/205526946-6ae151e5-c23a-4a4d-a58f-c5797020f993.gif)