### PR TITLE
[fix]: 회원 관리 테이블 내 추방 버튼 클릭 시 나타나는 문구 아이콘 변경 (#225)

### DIFF
--- a/src/pages/management/MemberManage.js
+++ b/src/pages/management/MemberManage.js
@@ -115,7 +115,7 @@ function MemberManage() {
             await api.delete("/api/users/" + id).then((result) => {
               searchAllUsers();
               Swal.fire({
-                icon: "info",
+                icon: "success",
                 title: `${username} 사용자를\n 정상적으로 제거하였습니다.`,
               });
             });


### PR DESCRIPTION
## 👀 이슈

resolve #225 

## 📌 개요

현재 관리자페이지 내 회원 관리 테이블에 위치한 `추방` 버튼 클릭 시
특정 문구와 함께 추방 여부를 다시금 확인하는 창이 나타나는데, 회원
삭제 완료 후 나타나는 창 내의 아이콘이 다소 모호하여 해당 부분을 알맞은
아이콘으로 변경하였습니다.

## 👩‍💻 작업 사항

- **`MemberManage.js`** 컴포넌트 내 `Swal.fire`의
icon 속성을 기존 `info`에서 `success`로 변경하였습니다.

## ✅ 참고 사항

- 기존 화면

![ezgif com-gif-maker (23)](https://user-images.githubusercontent.com/56868605/205722763-1e5c281e-2727-4725-a86d-5142a534f66a.gif)

- 수정 후 화면

![ezgif com-gif-maker (24)](https://user-images.githubusercontent.com/56868605/205723217-1a8c5db8-2db0-47ab-8416-8249dbfccbe4.gif)