### PR TITLE
[fix]: 로그인 페이지 스타일 수정 (#240)

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1772,7 +1772,6 @@ form textarea {
   -webkit-appearance: none;
   display: block;
   border: 0;
-  background: #e8e8e8;
   width: 100%;
   box-shadow: inset 2px 2px 0px 0px rgba(0, 0, 0, 0.1);
   border-radius: 4px;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -210,7 +210,7 @@ function Footer() {
               className="text-black border-0"
               style={{ marginLeft: "4.5rem" }}
             >
-              <i class="h2 fa-brands fa-github"></i>
+              <i className="h2 fa-brands fa-github"></i>
             </a>
           </div>
           <div

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -1,13 +1,19 @@
 import "./LoginPage.scss";
 import Swal from "sweetalert2";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
-// import { getCookie } from "../../hooks/useCookie";
 
 function LoginPage() {
   const navigate = useNavigate();
-  const [User, setUser] = useState({ studentId: "", password: "" });
+  const [isInit, setIsInit] = useState(false);
+  const [user, setUser] = useState({ studentId: "", password: "" });
+  const [showStudentNumInputDeleteBtn, setShowStudentNumInputDeleteBtn] =
+    useState(false);
+  const [showPasswordInputDeleteBtn, setShowPasswordInputDeleteBtn] =
+    useState(false);
+  const studentNumInputWidthChange = useRef(null);
+  const passwordInputWidthChange = useRef(null);
 
   const onLogin = (e) => {
     e.preventDefault();
@@ -18,7 +24,7 @@ function LoginPage() {
     axios
       .post(
         process.env.REACT_APP_URL + "/auth/login",
-        { ...User },
+        { ...user },
         { withCredentials: true }
       )
       .then((response) => {
@@ -71,36 +77,151 @@ function LoginPage() {
       });
   };
 
+  const inputWidthChangeHandler = (idx) => {
+    try {
+      switch (idx) {
+        case 0:
+          studentNumInputWidthChange.current.style = "width: 15.5rem;";
+          passwordInputWidthChange.current.style = "width: 15.5rem;";
+          break;
+        case 1:
+          studentNumInputWidthChange.current.style = "width: 15.5rem;";
+          break;
+        case 2:
+          passwordInputWidthChange.current.style = "width: 15.5rem;";
+          break;
+        default:
+          console.error("wrong idx value came!");
+      }
+    } catch (error) {
+      return;
+    }
+  };
+
   return (
-    <div className="LoginPage">
+    <div
+      className="LoginPage"
+      onClick={() => {
+        setIsInit(true);
+        inputWidthChangeHandler(0);
+        if (studentNumInputWidthChange.current.value !== "")
+          setShowStudentNumInputDeleteBtn(true);
+        if (passwordInputWidthChange.current.value !== "")
+          setShowPasswordInputDeleteBtn(true);
+      }}
+      onKeyDown={(e) => {
+        if (e.keyCode === undefined) return;
+        setIsInit(true);
+        inputWidthChangeHandler(0);
+        if (studentNumInputWidthChange.current.value !== "")
+          setShowStudentNumInputDeleteBtn(true);
+        if (passwordInputWidthChange.current.value !== "")
+          setShowPasswordInputDeleteBtn(true);
+      }}
+    >
       <div className="loginFrame">
         <form
           className="loginForm"
+          style={{
+            margin: "0 1.5rem",
+          }}
           onSubmit={(e) => {
             onLogin(e);
           }}
         >
-          <figure className="loginLogo">
+          <figure className="loginLogo" style={{ marginBottom: "0" }}>
             <img src="img/login_logo.png" alt="로그인 로고 이미지" />
           </figure>
-          <input
-            type={"text"}
-            autoComplete="username"
-            placeholder="학번"
-            required
-            onChange={(e) => {
-              setUser({ ...User, studentId: e.target.value });
-            }}
-          ></input>
-          <input
-            type={"password"}
-            autoComplete="current-password"
-            placeholder="비밀번호"
-            required
-            onChange={(e) => {
-              setUser({ ...User, password: e.target.value });
-            }}
-          ></input>
+          <div className="studentNumForm">
+            <input
+              className="studentNumInput"
+              type={"text"}
+              autoComplete="username"
+              placeholder="학번"
+              required
+              autoFocus
+              ref={studentNumInputWidthChange}
+              onFocus={() => {
+                inputWidthChangeHandler(0);
+              }}
+              onBlur={() => {
+                if (studentNumInputWidthChange.current.value !== "")
+                  inputWidthChangeHandler(1);
+                if (passwordInputWidthChange.current.value !== "")
+                  inputWidthChangeHandler(2);
+              }}
+              onClick={() => {
+                if (studentNumInputWidthChange.current.value === "")
+                  setShowStudentNumInputDeleteBtn(false);
+                else setShowStudentNumInputDeleteBtn(true);
+              }}
+              onChange={(e) => {
+                if (e.target.value === "")
+                  setShowStudentNumInputDeleteBtn(false);
+                else if (e.target.value !== "" && isInit) {
+                  setShowStudentNumInputDeleteBtn(true);
+                }
+                setUser({ ...user, studentId: e.target.value });
+              }}
+            ></input>
+            <div className="studentNum">
+              <i className="userIcon fa-solid fa-user"></i>
+              {showStudentNumInputDeleteBtn ? (
+                <div
+                  onClick={(e) => {
+                    studentNumInputWidthChange.current.value = "";
+                    setShowStudentNumInputDeleteBtn(false);
+                  }}
+                  className="studentNumDeleteBtn fa-solid fa-solid fa-circle-xmark"
+                ></div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="passwordForm">
+            <input
+              className="passwordInput"
+              type={"password"}
+              autoComplete="current-password"
+              placeholder="비밀번호"
+              required
+              ref={passwordInputWidthChange}
+              onFocus={() => {
+                inputWidthChangeHandler(0);
+              }}
+              onBlur={() => {
+                if (studentNumInputWidthChange.current.value !== "")
+                  inputWidthChangeHandler(1);
+                if (passwordInputWidthChange.current.value !== "")
+                  inputWidthChangeHandler(2);
+              }}
+              onClick={() => {
+                if (passwordInputWidthChange.current.value === "")
+                  setShowPasswordInputDeleteBtn(false);
+                else setShowPasswordInputDeleteBtn(true);
+              }}
+              onChange={(e) => {
+                if (e.target.value === "") setShowPasswordInputDeleteBtn(false);
+                else if (e.target.value !== "" && isInit) {
+                  setShowPasswordInputDeleteBtn(true);
+                }
+                setUser({ ...user, password: e.target.value });
+              }}
+            ></input>
+            <div className="password">
+              <i className="lockIcon fa-solid fa-lock"></i>
+              {showPasswordInputDeleteBtn ? (
+                <div
+                  onClick={(e) => {
+                    passwordInputWidthChange.current.value = "";
+                    setShowPasswordInputDeleteBtn(false);
+                  }}
+                  className="passwordDeleteBtn fa-solid fa-solid fa-circle-xmark"
+                ></div>
+              ) : null}
+            </div>
+          </div>
+
           <button id="loginBtn" type="submit">
             로그인
           </button>

--- a/src/pages/login/LoginPage.scss
+++ b/src/pages/login/LoginPage.scss
@@ -1,11 +1,131 @@
 .LoginPage {
-  input {
-    -webkit-appearance: auto;
-    appearance: auto;
+  .studentNumForm {
+    height: 2.75rem;
+    .studentNumInput {
+      width: 17.25rem;
+      // width: 15.5rem;
+      padding: 0;
+      position: relative;
+      top: 1.94rem;
+      left: 2.2rem;
+      box-shadow: none !important;
+      color: black;
+      border-radius: 0;
+      font-size: 17px;
+    }
+
+    .studentNumInput::placeholder {
+      color: #bfbfbf !important;
+    }
+
+    .studentNumInput:focus {
+      outline: none;
+      background-color: white;
+    }
+
+    .studentNumInput:focus ~ .studentNum {
+      border: 1.25px solid #4d69e2 !important;
+    }
+
+    .studentNumInput:focus ~ .studentNum > .userIcon {
+      color: rgb(108, 108, 108) !important;
+    }
+
+    .studentNum {
+      display: flex;
+      width: 20rem;
+      height: 2.75rem;
+      border: 1.25px solid #ddd;
+      border-bottom: none;
+      border-top-left-radius: 6px !important;
+      border-top-right-radius: 6px !important;
+      border-bottom-left-radius: 0px !important;
+      border-bottom-right-radius: 0px !important;
+
+      .userIcon {
+        padding: 0.9rem 0.9rem;
+        color: #bfbfbf !important;
+      }
+
+      .studentNumDeleteBtn {
+        font-size: 17px;
+        padding: 0 !important;
+        position: relative;
+        left: 15.6rem;
+        top: 0.8rem;
+        box-shadow: none;
+        background-color: transparent;
+        color: #9ba1a3 !important;
+        cursor: pointer;
+      }
+    }
   }
+
+  .passwordForm {
+    margin-bottom: 0.5rem;
+    .passwordInput {
+      width: 17.25rem;
+      // width: 15.5rem;
+      padding: 0;
+      position: relative;
+      top: 1.94rem;
+      left: 2.2rem;
+      box-shadow: none !important;
+      color: black;
+      border-radius: 0;
+      font-size: 17px;
+    }
+
+    .passwordInput::placeholder {
+      color: #bfbfbf !important;
+    }
+
+    .passwordInput:focus {
+      outline: none;
+      background-color: white;
+    }
+
+    .passwordInput:focus ~ .password {
+      border: 1.25px solid #4d69e2 !important;
+    }
+
+    .passwordInput:focus ~ .password > .lockIcon {
+      color: rgb(108, 108, 108) !important;
+    }
+
+    .password {
+      display: flex;
+      width: 20rem;
+      height: 2.75rem;
+      border: 1.25px solid #ddd;
+      border-top-left-radius: 0px !important;
+      border-top-right-radius: 0px !important;
+      border-bottom-left-radius: 6px !important;
+      border-bottom-right-radius: 6px !important;
+
+      .lockIcon {
+        padding: 0.9rem 0.9rem;
+        color: #bfbfbf !important;
+      }
+
+      .passwordDeleteBtn {
+        font-size: 17px;
+        padding: 0 !important;
+        position: relative;
+        left: 15.6rem;
+        top: 0.8rem;
+        box-shadow: none;
+        background-color: transparent;
+        color: #9ba1a3 !important;
+        cursor: pointer;
+      }
+    }
+  }
+
   width: 100%;
   display: flex;
   justify-content: center;
+  font-size: 15px;
   .loginFrame {
     min-width: 400px;
   }
@@ -18,19 +138,14 @@
     flex-direction: column;
 
     #loginBtn {
-      font-size: 17px;
-      height: 2.5rem;
-      line-height: 2.1rem;
+      font-size: 15px;
+      height: 2.25rem;
+      line-height: 1.85rem;
       margin-top: 0.5rem;
       letter-spacing: -0.25px;
-      font-weight: 700;
+      font-weight: 600;
       border-radius: 4px;
     }
-  }
-  input {
-    font-size: 1.2em;
-    margin-bottom: 2%;
-    padding-left: 2%;
   }
   button {
     font-size: 1.2em;
@@ -58,6 +173,8 @@
     .signUp,
     .findPassword {
       border: none;
+      color: grey;
+      font-size: 14px;
     }
   }
   .autoLoginFrame {


### PR DESCRIPTION
## 👀 이슈

resolve #240 

## 📌 개요

로그인 페이지 디자인 스타일을 변경하고자 하였습니다.

## 👩‍💻 작업 사항

- `LoginPage.js` 파일 내 입력 폼 관련 요소 추가 및 수정
- `LoginPage.scss` 파일 수정에 따른 스타일 변경
- `Footer.js` 파일 내 깃헙 아이콘 요소의 class -> className으로 속성명 수정
- `main.css` 파일 내 input 요소의 배경색 스타일을 지정하는 속성 제거

## ✅ 참고 사항

- 수정 전

<img width="453" alt="Screenshot 2022-12-21 at 1 37 34 AM" src="https://user-images.githubusercontent.com/56868605/208718704-7fb58a3d-ab4b-4d01-bdbd-60f28a631b73.png">

- 수정 후 (처음: 자동완성[autocomplete]이 적용된 경우, 이후: Chrome 시크릿 모드로 저장된 아이디, 비밀번호 데이터가 없는 초기 상태에서 로그인 페이지에  접근하였을 경우로 구분 지어 녹화하였습니다)

https://user-images.githubusercontent.com/56868605/209346497-b90a086d-84ee-4491-a646-65bbcfed5e13.mov