### PR TITLE
[fix]: 게시글 내 첨부파일 요소 디자인 변경 (#203)

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -210,7 +210,7 @@ function Footer() {
               className="text-black border-0"
               style={{ marginLeft: "4.5rem" }}
             >
-              <i class="h2 fa-brands fa-github"></i>
+              <i className="h2 fa-brands fa-github" />
             </a>
           </div>
           <div

--- a/src/components/UploadedFilesInArticle.js
+++ b/src/components/UploadedFilesInArticle.js
@@ -1,0 +1,36 @@
+export const UploadedFilesInArticle = ({ location, article }) => {
+  return (
+    <section className="fileSection m-0">
+      {article.files.length !== 0 ? (
+        <div className="row">
+          <div
+            className="col-1 text-center p-0 ml-3"
+            style={{ margin: "auto 0" }}
+          >
+            <strong style={{ color: "black" }}>파일</strong>
+          </div>
+          <div className="files col">
+            {article.files.map((file, id) => (
+              <div key={id} className="uploadedFile">
+                <a
+                  href={
+                    process.env.REACT_APP_URL +
+                    "/no-permit/api/boards/" +
+                    location.state.boardId +
+                    "/articles/" +
+                    location.state.articleId +
+                    "/files/" +
+                    file.filePath
+                  }
+                  className="text-decoration-none"
+                >
+                  {file.fileName}
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/src/pages/exam/ExamDetail.scss
+++ b/src/pages/exam/ExamDetail.scss
@@ -5,13 +5,37 @@
   .container {
     display: flex;
     flex-direction: column;
-
     width: 80%;
     margin-top: 150px;
-
     > div {
       padding-left: 1%;
       padding-right: 1%;
+    }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
     }
   }
 

--- a/src/pages/exam/ExamDetailPage.js
+++ b/src/pages/exam/ExamDetailPage.js
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import "./ExamDetail.scss";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
 
 function ExamDetailPage() {
@@ -62,33 +63,7 @@ function ExamDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame mt-5">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/exam/ExamUpdate.js
+++ b/src/pages/exam/ExamUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -35,29 +35,24 @@ function ExamUpdate() {
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else {
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
 
       for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({ 'url': currentFileUrl, 'name': fileLists[i].name });
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-
-
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
     setUploadFile(uploadFile.filter((_, index) => index !== id));
   };
-
-
 
   const onSubmit = (e) => {
     e.preventDefault();
@@ -69,7 +64,7 @@ function ExamUpdate() {
 
         let formData = new FormData();
         for (let i = 0; i < uploadFile.length; i++) {
-          formData.append("file", uploadFile[i])
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -153,28 +148,40 @@ function ExamUpdate() {
             }}
           />
         </Form.Group>
-          <Form.Group className="mb-3">
-            <Form.Label>등록된 파일</Form.Label>
-            {showFiles.length ?
-              <Card>
-                <ListGroup variant="flush">
-                  {showFiles.map((file, id) => (
-                    <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                      <span>
-                        <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                          <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z" />
-                          <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
-                        </svg>
-                        {file.name}
-                      </span>
-                      <span style={{ cursor: 'pointer' }} onClick={() => handleDeleteImage(id)}>X</span>
-                    </ListGroup.Item>
-                  ))}
-                </ListGroup>
-              </Card>
-              :
-              null
-            }
+        <Form.Group className="mb-3">
+          <Form.Label>등록된 파일</Form.Label>
+          {showFiles.length ? (
+            <Card>
+              <ListGroup variant="flush">
+                {showFiles.length ? (
+                  <Card>
+                    <ListGroup variant="flush">
+                      {showFiles.map((file, id) => (
+                        <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                          <span>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24"
+                              width="24"
+                            >
+                              <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                            </svg>
+                            &nbsp;{file.name}
+                          </span>
+                          <span
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleDeleteImage(id)}
+                          >
+                            <i className="fa-solid fa-xmark" />
+                          </span>
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card>
+                ) : null}
+              </ListGroup>
+            </Card>
+          ) : null}
         </Form.Group>
         <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
           <Form.Label>내용</Form.Label>

--- a/src/pages/freeBoard/FreeBoardDetail.scss
+++ b/src/pages/freeBoard/FreeBoardDetail.scss
@@ -5,13 +5,37 @@
   .container {
     display: flex;
     flex-direction: column;
-
     width: 80%;
     margin-top: 150px;
-
     > div {
       padding-left: 1%;
       padding-right: 1%;
+    }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
     }
   }
 

--- a/src/pages/freeBoard/FreeBoardDetailPage.js
+++ b/src/pages/freeBoard/FreeBoardDetailPage.js
@@ -4,6 +4,7 @@ import "./FreeBoardDetail.scss";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 
 function FreeBoardDetailPage() {
   const navigate = useNavigate();
@@ -62,33 +63,7 @@ function FreeBoardDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame mt-5">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/freeBoard/FreeBoardUpdate.js
+++ b/src/pages/freeBoard/FreeBoardUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -35,20 +35,19 @@ function FreeBoardUpdate() {
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else {
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
 
       for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({ 'url': currentFileUrl, 'name': fileLists[i].name });
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
@@ -65,7 +64,7 @@ function FreeBoardUpdate() {
 
         let formData = new FormData();
         for (let i = 0; i < uploadFile.length; i++) {
-          formData.append("file", uploadFile[i])
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -151,26 +150,38 @@ function FreeBoardUpdate() {
         </Form.Group>
         <Form.Group className="mb-3">
           <Form.Label>등록된 파일</Form.Label>
-          {showFiles.length ?
+          {showFiles.length ? (
             <Card>
               <ListGroup variant="flush">
-                {showFiles.map((file, id) => (
-                  <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                    <span>
-                      <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                        <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z" />
-                        <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
-                      </svg>
-                      {file.name}
-                    </span>
-                    <span style={{ cursor: 'pointer' }} onClick={() => handleDeleteImage(id)}>X</span>
-                  </ListGroup.Item>
-                ))}
+                {showFiles.length ? (
+                  <Card>
+                    <ListGroup variant="flush">
+                      {showFiles.map((file, id) => (
+                        <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                          <span>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24"
+                              width="24"
+                            >
+                              <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                            </svg>
+                            &nbsp;{file.name}
+                          </span>
+                          <span
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleDeleteImage(id)}
+                          >
+                            <i className="fa-solid fa-xmark" />
+                          </span>
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card>
+                ) : null}
               </ListGroup>
             </Card>
-            :
-            null
-          }
+          ) : null}
         </Form.Group>
         <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
           <Form.Label>내용</Form.Label>

--- a/src/pages/notice/NoticeDetail.scss
+++ b/src/pages/notice/NoticeDetail.scss
@@ -11,6 +11,32 @@
       padding-left: 1%;
       padding-right: 1%;
     }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
+    }
   }
 
   .pageTitle {

--- a/src/pages/notice/NoticeDetailPage.js
+++ b/src/pages/notice/NoticeDetailPage.js
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 
 function NoticeDetailPage() {
   const navigate = useNavigate();
@@ -51,7 +52,6 @@ function NoticeDetailPage() {
                 ) : (
                   <i className="fa-regular fa-thumbs-up"></i>
                 )}
-                {/* "article.likeCnt"와 "article.viewCnt"의 값이 동일하게 넘어오는 문제가 있습니다(수정 필요!!) */}
                 {like ? (
                   <span className="likeCnt font-weight-bold">
                     {article.likeCnt + 1}
@@ -62,33 +62,7 @@ function NoticeDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame mt-5">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/notice/NoticeUpdate.js
+++ b/src/pages/notice/NoticeUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -14,7 +14,7 @@ function NoticeRegisteration() {
   const [uploadFile, setUploadFile] = useState([]);
   const [showFiles, setShowFiles] = useState([]);
   const navigate = useNavigate();
-  
+
   useEffect(() => {
     myRole().then((response) => {
       if (response === "not authorized") {
@@ -39,36 +39,32 @@ function NoticeRegisteration() {
     });
   }, []);
 
-  const fileChange = (e) =>{
+  const fileChange = (e) => {
     const fileLists = e.target.files;
 
-    if (fileLists.length + uploadFile.length > 5){
+    if (fileLists.length + uploadFile.length > 5) {
       Swal.fire({
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else{
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
-  
-      for (let i = 0; i < fileLists.length; i++){
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
+
+      for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({'url' : currentFileUrl, 'name' : fileLists[i].name});
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-    
-
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
     setUploadFile(uploadFile.filter((_, index) => index !== id));
   };
-
 
   const onSubmit = (e) => {
     e.preventDefault();
@@ -79,8 +75,8 @@ function NoticeRegisteration() {
         noticeBtn.innerText = "글등록 중...";
 
         let formData = new FormData();
-        for (let i = 0; i < uploadFile.length; i++){
-          formData.append("file", uploadFile[i])
+        for (let i = 0; i < uploadFile.length; i++) {
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -172,27 +168,32 @@ function NoticeRegisteration() {
                 </Form.Group>
                 <Form.Group className="mb-3">
                   <Form.Label>등록된 파일</Form.Label>
-                  {showFiles.length?
+                  {showFiles.length ? (
                     <Card>
-                    <ListGroup variant="flush">
-                    { showFiles.map((file, id) => (
-                        <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                          <span>
-                            <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                              <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z"/>
-                              <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z"/>
-                            </svg>
-                            {file.name}
-                          </span>
-                          <span style={{cursor : 'pointer'}} onClick={() => handleDeleteImage(id)}>X</span>
-                        </ListGroup.Item>
-                      ))}
-                    </ListGroup>
+                      <ListGroup variant="flush">
+                        {showFiles.map((file, id) => (
+                          <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                            <span>
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                height="24"
+                                width="24"
+                              >
+                                <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                              </svg>
+                              &nbsp;{file.name}
+                            </span>
+                            <span
+                              style={{ cursor: "pointer" }}
+                              onClick={() => handleDeleteImage(id)}
+                            >
+                              <i className="fa-solid fa-xmark" />
+                            </span>
+                          </ListGroup.Item>
+                        ))}
+                      </ListGroup>
                     </Card>
-                    :
-                    null
-
-                  }
+                  ) : null}
                 </Form.Group>
                 <Form.Group
                   className="mb-3"

--- a/src/pages/report/ReportDetail.scss
+++ b/src/pages/report/ReportDetail.scss
@@ -5,13 +5,37 @@
   .container {
     display: flex;
     flex-direction: column;
-
     width: 80%;
     margin-top: 150px;
-
     > div {
       padding-left: 1%;
       padding-right: 1%;
+    }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
     }
   }
 

--- a/src/pages/report/ReportDetailPage.js
+++ b/src/pages/report/ReportDetailPage.js
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import "./ReportDetail.scss";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
 
 function ReportDetailPage() {
@@ -63,33 +64,7 @@ function ReportDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/report/ReportUpdate.js
+++ b/src/pages/report/ReportUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -35,22 +35,19 @@ function ReportUpdate() {
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else {
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
 
       for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({ 'url': currentFileUrl, 'name': fileLists[i].name });
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-
-
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
@@ -67,7 +64,7 @@ function ReportUpdate() {
 
         let formData = new FormData();
         for (let i = 0; i < uploadFile.length; i++) {
-          formData.append("file", uploadFile[i])
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -152,27 +149,39 @@ function ReportUpdate() {
           />
         </Form.Group>
         <Form.Group className="mb-3">
-            <Form.Label>등록된 파일</Form.Label>
-            {showFiles.length ?
-              <Card>
-                <ListGroup variant="flush">
-                  {showFiles.map((file, id) => (
-                    <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                      <span>
-                        <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                          <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z" />
-                          <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
-                        </svg>
-                        {file.name}
-                      </span>
-                      <span style={{ cursor: 'pointer' }} onClick={() => handleDeleteImage(id)}>X</span>
-                    </ListGroup.Item>
-                  ))}
-                </ListGroup>
-              </Card>
-              :
-              null
-            }
+          <Form.Label>등록된 파일</Form.Label>
+          {showFiles.length ? (
+            <Card>
+              <ListGroup variant="flush">
+                {showFiles.length ? (
+                  <Card>
+                    <ListGroup variant="flush">
+                      {showFiles.map((file, id) => (
+                        <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                          <span>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24"
+                              width="24"
+                            >
+                              <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                            </svg>
+                            &nbsp;{file.name}
+                          </span>
+                          <span
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleDeleteImage(id)}
+                          >
+                            <i className="fa-solid fa-xmark" />
+                          </span>
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card>
+                ) : null}
+              </ListGroup>
+            </Card>
+          ) : null}
         </Form.Group>
         <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
           <Form.Label>내용</Form.Label>

--- a/src/pages/seminar/SeminarDetail.scss
+++ b/src/pages/seminar/SeminarDetail.scss
@@ -5,13 +5,37 @@
   .container {
     display: flex;
     flex-direction: column;
-
     width: 80%;
     margin-top: 150px;
-
     > div {
       padding-left: 1%;
       padding-right: 1%;
+    }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
     }
   }
 

--- a/src/pages/seminar/SeminarDetailPage.js
+++ b/src/pages/seminar/SeminarDetailPage.js
@@ -4,6 +4,7 @@ import "./SeminarDetail.scss";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 
 function SeminarDetailPage() {
   const navigate = useNavigate();
@@ -62,33 +63,7 @@ function SeminarDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame mt-5">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/seminar/SeminarUpdate.js
+++ b/src/pages/seminar/SeminarUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -35,22 +35,19 @@ function SeminarUpdate() {
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else {
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
 
       for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({ 'url': currentFileUrl, 'name': fileLists[i].name });
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-
-
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
@@ -67,7 +64,7 @@ function SeminarUpdate() {
 
         let formData = new FormData();
         for (let i = 0; i < uploadFile.length; i++) {
-          formData.append("file", uploadFile[i])
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -153,26 +150,38 @@ function SeminarUpdate() {
         </Form.Group>
         <Form.Group className="mb-3">
           <Form.Label>등록된 파일</Form.Label>
-          {showFiles.length ?
+          {showFiles.length ? (
             <Card>
               <ListGroup variant="flush">
-                {showFiles.map((file, id) => (
-                  <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                    <span>
-                      <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                        <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z" />
-                        <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
-                      </svg>
-                      {file.name}
-                    </span>
-                    <span style={{ cursor: 'pointer' }} onClick={() => handleDeleteImage(id)}>X</span>
-                  </ListGroup.Item>
-                ))}
+                {showFiles.length ? (
+                  <Card>
+                    <ListGroup variant="flush">
+                      {showFiles.map((file, id) => (
+                        <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                          <span>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24"
+                              width="24"
+                            >
+                              <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                            </svg>
+                            &nbsp;{file.name}
+                          </span>
+                          <span
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleDeleteImage(id)}
+                          >
+                            <i className="fa-solid fa-xmark" />
+                          </span>
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card>
+                ) : null}
               </ListGroup>
             </Card>
-            :
-            null
-          }
+          ) : null}
         </Form.Group>
         <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
           <Form.Label>내용</Form.Label>

--- a/src/pages/subProject/ProjectDetail.scss
+++ b/src/pages/subProject/ProjectDetail.scss
@@ -5,13 +5,37 @@
   .container {
     display: flex;
     flex-direction: column;
-
     width: 80%;
     margin-top: 150px;
-
     > div {
       padding-left: 1%;
       padding-right: 1%;
+    }
+
+    .fileSection {
+      margin-top: 1.25rem !important;
+      border-top: 0.5px solid #b6b6b6;
+      border-bottom: 0.5px solid #b6b6b6;
+      background-color: #f4f4f4;
+      font-size: 14px;
+
+      .files {
+        padding: 0;
+        background-color: #fff;
+        .uploadedFile {
+          margin: 0.2rem 0;
+          padding-left: 0.5rem;
+          padding-bottom: 0.1rem;
+          & > a {
+            color: black;
+            border: none;
+            transition: none;
+          }
+          & > a:hover {
+            border-bottom: 1px solid black;
+          }
+        }
+      }
     }
   }
 

--- a/src/pages/subProject/ProjectDetailPage.js
+++ b/src/pages/subProject/ProjectDetailPage.js
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import "./ProjectDetail.scss";
+import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
 
 function ProjectDetailPage() {
@@ -62,33 +63,7 @@ function ProjectDetailPage() {
               </span>
             </div>
           </div>
-          {article.files.length !== 0 ? (
-            <div className="file-download-frame mt-5">
-              파일 다운로드
-              <br />
-              {article.files.map((file, id) => (
-                <div key={id}>
-                  <a
-                    href={
-                      process.env.REACT_APP_URL +
-                      "/no-permit/api/boards/" +
-                      location.state.boardId +
-                      "/articles/" +
-                      location.state.articleId +
-                      "/files/" +
-                      file.filePath
-                    }
-                    className="text-decoration-none"
-                    key={id}
-                  >
-                    {file.fileName}
-                  </a>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div></div>
-          )}
+          <UploadedFilesInArticle location={location} article={article} />
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/subProject/ProjectUpdate.js
+++ b/src/pages/subProject/ProjectUpdate.js
@@ -1,6 +1,6 @@
 import { Form, Button } from "react-bootstrap";
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
 import React, { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import api from "../../utils/api";
@@ -27,7 +27,6 @@ function ProjectUpdate() {
     });
   }, []);
 
-
   const fileChange = (e) => {
     const fileLists = e.target.files;
 
@@ -36,22 +35,19 @@ function ProjectUpdate() {
         icon: "warning",
         title: "파일첨부를 5개 초과할 수 없습니다.",
       });
-    }
-    else {
-      let fileUrlLists = [...showFiles]
-      let uploadFileLists = [...uploadFile]
+    } else {
+      let fileUrlLists = [...showFiles];
+      let uploadFileLists = [...uploadFile];
 
       for (let i = 0; i < fileLists.length; i++) {
         uploadFileLists.push(fileLists[i]);
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
-        fileUrlLists.push({ 'url': currentFileUrl, 'name': fileLists[i].name });
+        fileUrlLists.push({ url: currentFileUrl, name: fileLists[i].name });
       }
-      setShowFiles(fileUrlLists)
+      setShowFiles(fileUrlLists);
       setUploadFile(uploadFileLists);
     }
-
-
-  }
+  };
 
   const handleDeleteImage = (id) => {
     setShowFiles(showFiles.filter((_, index) => index !== id));
@@ -68,7 +64,7 @@ function ProjectUpdate() {
 
         let formData = new FormData();
         for (let i = 0; i < uploadFile.length; i++) {
-          formData.append("file", uploadFile[i])
+          formData.append("file", uploadFile[i]);
         }
 
         formData.append(
@@ -154,26 +150,38 @@ function ProjectUpdate() {
         </Form.Group>
         <Form.Group className="mb-3">
           <Form.Label>등록된 파일</Form.Label>
-          {showFiles.length ?
+          {showFiles.length ? (
             <Card>
               <ListGroup variant="flush">
-                {showFiles.map((file, id) => (
-                  <ListGroup.Item className="d-flex justify-content-between align-items-center" >
-                    <span>
-                      <svg className="me-2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-code" viewBox="0 0 16 16">
-                        <path d="M6.646 5.646a.5.5 0 1 1 .708.708L5.707 8l1.647 1.646a.5.5 0 0 1-.708.708l-2-2a.5.5 0 0 1 0-.708l2-2zm2.708 0a.5.5 0 1 0-.708.708L10.293 8 8.646 9.646a.5.5 0 0 0 .708.708l2-2a.5.5 0 0 0 0-.708l-2-2z" />
-                        <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
-                      </svg>
-                      {file.name}
-                    </span>
-                    <span style={{ cursor: 'pointer' }} onClick={() => handleDeleteImage(id)}>X</span>
-                  </ListGroup.Item>
-                ))}
+                {showFiles.length ? (
+                  <Card>
+                    <ListGroup variant="flush">
+                      {showFiles.map((file, id) => (
+                        <ListGroup.Item className="d-flex justify-content-between align-items-center">
+                          <span>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24"
+                              width="24"
+                            >
+                              <path d="M6.3 21.5q-.75 0-1.275-.525Q4.5 20.45 4.5 19.7V4.3q0-.75.525-1.275Q5.55 2.5 6.3 2.5h7.95l5.25 5.25V19.7q0 .75-.525 1.275-.525.525-1.275.525Zm7.2-13V4H6.3q-.1 0-.2.1t-.1.2v15.4q0 .1.1.2t.2.1h11.4q.1 0 .2-.1t.1-.2V8.5ZM6 4v4.5V4 20 4Z" />
+                            </svg>
+                            &nbsp;{file.name}
+                          </span>
+                          <span
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleDeleteImage(id)}
+                          >
+                            <i className="fa-solid fa-xmark" />
+                          </span>
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card>
+                ) : null}
               </ListGroup>
             </Card>
-            :
-            null
-          }
+          ) : null}
         </Form.Group>
         <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
           <Form.Label>내용</Form.Label>


### PR DESCRIPTION
## 👀 이슈

resolve #203

## 📌 개요

게시글 컴포넌트 하단에 배치되어 있는 `첨부파일` 요소의
디자인을 변경하여 좀 더 깔끔하게 변경하고자 하였습니다.

## 👩‍💻 작업 사항

- 첨부파일 컴포넌트 추가
- `공지사항` 게시판 게시글 내 첨부파일 란 디자인 수정
- `자유게시판` 게시판 게시글 내 첨부파일 란 디자인 수정
- `특강자료` 게시판 게시글 내 첨부파일 란 디자인 수정
- `활동보고서` 게시판 게시글 내 첨부파일 란 디자인 수정
- `소규모 프로젝트` 게시판 게시글 내 첨부파일 란 디자인 수정
- `족보` 게시판 게시글 내 첨부파일 란 디자인 수정
- `Footer.js` 컴포넌트 내 깃헙 아이콘 요소의 class -> className 속성명 변경

## ✅ 참고 사항

- 변경 전 `첨부파일`

![스크린샷 2022-10-26 오전 12 11 09](https://user-images.githubusercontent.com/56868605/197813087-0372dc08-4104-4852-856d-11789b0dda37.png)

- 변경 후 `첨부파일`
- <img width="1151" alt="Screenshot 2022-12-24 at 4 48 12 PM" src="https://user-images.githubusercontent.com/56868605/209439182-04c97c61-a121-4c5f-8922-c1c9797574cc.png">
![ezgif com-gif-maker (31)](https://user-images.githubusercontent.com/56868605/209439253-c6d861d5-819e-4280-9b25-21b319e4d3fa.gif)