### PR TITLE
[fix]: 게시글 댓글 '수정 & 삭제' 기능 사용의 대상 설정 로직 수정 (#247)

### DIFF
--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -21,7 +21,7 @@ function Comment(props) {
       try {
         await api.get("/no-permit/api/user/info").then((response) => {
           if (response.data.success) {
-            setUserInfo(response.data);
+            setUserInfo(response.data.response);
           } else {
             setUserInfo(null);
           }
@@ -30,7 +30,7 @@ function Comment(props) {
         localStorage.clear();
       }
     }
-    localStorage.getItem('sm-accessToken') && getUserInfo();
+    localStorage.getItem("sm-accessToken") && getUserInfo();
     myRole().then((response) => {
       setRole(response);
     });
@@ -245,7 +245,7 @@ function Comment(props) {
                     </div>
                     <p className="content">{comment.content}</p>
                     <div className="commentControl">
-                      {userInfo.response.username === comments[i].author ? (
+                      {userInfo.userId === comments[i].userId ? (
                         <>
                           <button
                             className="modifyingComment"
@@ -258,7 +258,7 @@ function Comment(props) {
                         </>
                       ) : null}
                       {role === "admin" ||
-                      userInfo.response.username === comment.author ? (
+                      userInfo.userId === comment.userId ? (
                         <button
                           className="deletingComment"
                           onClick={() => deleteComment(comment.id)}
@@ -267,7 +267,6 @@ function Comment(props) {
                         </button>
                       ) : null}
                     </div>
-                    {/* <span>디엠 수정</span> */}
                   </td>
                 </tr>
               ))

--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -3,7 +3,6 @@ import api from "../utils/api";
 import "./Comment.scss";
 import Swal from "sweetalert2";
 import { checkExpiredAccesstoken, myRole } from "../hooks/useAuth";
-import { delCookie, getCookie } from "../hooks/useCookie";
 
 function Comment(props) {
   const [page, setPage] = useState([]);


### PR DESCRIPTION
## 👀 이슈

resolve #247 

## 📌 개요

현재 게시글 내 위치한 `댓글` 컴포넌트의 (수정, 삭제) 기능을 수행하려면,
해당 댓글을 게시한 사용자 혹은 관리자에 한하여 이용이 가능한데, 현재
컴포넌트 로직 상으로, `댓글 게시자 이름`이 **동일하면** 위 두 기능들을 정상적으로
사용 가능하게 설정되어있어, 다른 사용자일지라도 같은 유저명으로 회원가입이 된다면,
다른 이의 댓글 (수정, 삭제) 악용 가능성이 발생할 수 있어 동일 유저명이 아닌, DB 내
기본키로 사용되고 있는 userId를 기반으로 (수정, 삭제) 기능을 이용할 수 있도록 코드를
수정하였습니다.

## 👩‍💻 작업 사항

- **`Comment.js`** 파일 내 댓글 (수정, 삭제) 기능 사용 로직을 기존 유저명에서 **userId**로 변경합니다.
- **`Comment.js`** 파일 내 불필요한 span 요소를 제거합니다.

## ✅ 참고 사항

- 기존 댓글 (수정, 삭제) 허용 로직

<img width="423" alt="before" src="https://user-images.githubusercontent.com/56868605/209896417-7ebfc474-c42d-4264-992b-703fb1023e31.png">

- 수정 후 댓글 (수정, 삭제) 허용 로직

<img width="399" alt="after_0" src="https://user-images.githubusercontent.com/56868605/209896693-174b77e6-b5e7-438e-9e94-9449c101f2f9.png">