### PR TITLE
[feat]: 관리자의 사용자 기수 설정 기능 추가 (#249)

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -151,6 +151,10 @@ input::-moz-focus-inner {
   padding: 0;
 }
 
+input::placeholder {
+  color: #aaa;
+}
+
 input,
 textarea {
   -moz-appearance: none;
@@ -1815,40 +1819,44 @@ form ::-moz-focus-inner {
 
 table {
   width: 100%;
+  border: none !important;
+  border-radius: 5px;
+  border-collapse: separate !important;
+  box-shadow: 5px 5px 15px rgb(202, 202, 202);
+  margin-top: 1rem !important;
 }
 
-table tbody tr {
-  border-top: solid 1px #e5e5e5;
-}
-
-table tbody tr:first-child {
-  border-top: 0;
+table tr {
+  text-align: left;
+  font-size: 13px !important;
 }
 
 table td {
+  border: none !important;
   padding: 0.75em 1em 0.75em 1em;
+}
+
+table tr:nth-child(2n) {
+  background-color: rgb(245, 245, 245);
 }
 
 table th {
-  text-align: left;
-  font-weight: bold;
-  padding: 0.75em 1em 0.75em 1em;
+  padding: 0.3em 1em;
+  border: none !important;
+}
+
+table th:first-child {
+  border-radius: 5px 0 0 0;
+}
+
+table th:last-child {
+  border-radius: 0 5px 0 0;
 }
 
 table thead {
-  background: #878787;
-  color: #fff;
-  font-weight: 400;
+  color: white;
+  background-color: #444;
   text-transform: uppercase;
-  border: 0;
-  box-shadow: 0.125em 0.175em 0 0 rgba(0, 0, 0, 0.125);
-  font-size: 0.85em;
-  letter-spacing: 2px;
-}
-
-table tfoot {
-  background: #f0f0f0;
-  border-top: solid 2px #e5e5e5;
 }
 
 /* Button */

--- a/src/pages/main/Board.scss
+++ b/src/pages/main/Board.scss
@@ -1,16 +1,11 @@
-.Board{
-    *{font-size: 1.02em;}
-    table td:nth-child(1){
-        width: 10%;
-    }
-    table td:nth-child(2){
-        width: 15%;
-    }
-    table td:nth-child(4){
-        width: 15%;
-    }
-
+.Board {
+  table td:nth-child(1) {
+    width: 10%;
+  }
+  table td:nth-child(2) {
+    width: 15%;
+  }
+  table td:nth-child(4) {
+    width: 15%;
+  }
 }
-
-
-

--- a/src/pages/management/MemberManage.jsx
+++ b/src/pages/management/MemberManage.jsx
@@ -140,6 +140,51 @@ function MemberManage() {
     });
   };
 
+  const modifyUserCardinalHandler = (username, userId, generation) => {
+    checkExpiredAccesstoken().then((response) => {
+      Swal.fire({
+        icon: "info",
+        title: `${username} 사용자를\n${generation}기 회원으로\n변경하시겠습니까?`,
+        showDenyButton: true,
+        confirmButtonText: "네",
+        denyButtonText: `아니요`,
+      }).then(async (response) => {
+        if (response.isConfirmed) {
+          try {
+            await api
+              .patch(`/api/users/${userId}/generation`, { generation })
+              .then((result) => {
+                searchAllUsers();
+                Swal.fire({
+                  icon: "success",
+                  title: `정상적으로 변경되었습니다.`,
+                });
+              });
+          } catch (error) {
+            if (error.response.status === 406) {
+              Swal.fire({
+                icon: "error",
+                title: `관리자 권한을 지닌\n사용자는 제거할 수 없습니다.`,
+              });
+            } else {
+              Swal.fire({
+                icon: "error",
+                title: "예기치 못 한 에러가 발생하였습니다.",
+              });
+              console.log(
+                "🚀 ~ file: MemberManage.jsx:177 ~ checkExpiredAccesstoken ~ error",
+                error
+              );
+              // window.location.href = "/login";
+            }
+          }
+        } else {
+          return;
+        }
+      });
+    });
+  };
+
   return (
     <div id="MemberManage">
       <form className="d-flex align-items-center">
@@ -165,12 +210,12 @@ function MemberManage() {
       </form>
       {loading ? (
         <table>
-          <colgroup></colgroup>
           <thead>
             <tr>
               <th>이름</th>
               <th>학번</th>
               <th>이메일</th>
+              <th>기수</th>
               <th>회원권한</th>
               <th>회원제거</th>
             </tr>
@@ -183,6 +228,29 @@ function MemberManage() {
                   <td>{member.username}</td>
                   <td>{member.studentId}</td>
                   <td>{member.email}</td>
+                  <td>
+                    <input
+                      type="number"
+                      placeholder={member.generation}
+                      onChange={(e) => {
+                        if (e.target.value < 0) e.target.value = 0;
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.keyCode === 13)
+                          modifyUserCardinalHandler(
+                            member.username,
+                            member.userId,
+                            e.target.value
+                          );
+                      }}
+                      style={{
+                        height: "1.5rem",
+                        fontSize: "15px",
+                        color: "black",
+                        borderRadius: "2.5px",
+                      }}
+                    />
+                  </td>
                   <td>
                     <select
                       className="authorityKinds text-center"

--- a/src/pages/management/MemberManage.scss
+++ b/src/pages/management/MemberManage.scss
@@ -6,6 +6,7 @@
     width: 20%;
     margin-right: 2%;
     font-size: 1.2em;
+    padding-left: 2.5px;
   }
 
   input::placeholder {
@@ -21,9 +22,7 @@
 
   table {
     width: 100%;
-
     margin-top: 1%;
-
     border: 1px solid black;
     text-align: center;
   }
@@ -33,16 +32,21 @@
     border: 1px solid black;
     font-size: 1.2em;
     & > button {
+      padding-left: 17px !important;
+      line-height: 1.5rem;
+      border: 1px solid rgb(224, 224, 224);
+      letter-spacing: 1rem;
       border-radius: 5px;
       box-shadow: none;
       padding: 0;
-      font-size: 1.1rem;
+      font-size: 13px;
       width: 5rem;
-      height: 1.8rem;
+      height: 1.5rem;
     }
-  }
-  th {
-    font-size: 1.5em;
-    font-weight: bold;
+    & > input {
+      width: 3rem;
+      height: 2rem;
+      border: 1px solid black;
+    }
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #249 

## 📌 개요

지난 동아리 회원에 대한 `이름` 및 `이미지`가 홈페이지에 추가되어
있는 상태인데, 그 이후부터 가입한 회원에 대해서는 별도의 기수 관리가
되지 않아 해당 페이지에 추가가 되지 못 했던 문제가 있어 해당 작업을
추후에 이어서 수행 가능하도록 기수 추가 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 관리자는 `관리자 페이지` 내에서 현재 홈페이지에 가입한 회원에 대한 기수 설정 기능이 추가됩니다.
- 관리자페이지 회원관리 메뉴 내 table 요소의 디자인이 변경됩니다.
- 메인페이지 내 공지사항 table 요소의 디자인이 변경됩니다.

## ✅ 참고 사항

- 이전의 관리자 페이지 내 `회원관리` 메뉴 탭의 구성

![Screenshot 2023-01-02 at 2 43 15 AM](https://user-images.githubusercontent.com/56868605/210180046-e6dd5f8c-b4d7-4a2d-8314-c72090421f57.png)

- 이전의 메인페이지 내 공지사항 테이블 디자인

![Screenshot 2023-01-03 at 10 22 16 PM](https://user-images.githubusercontent.com/56868605/210367917-04aea204-ab0a-4ce4-a08b-b9aa6abbf1f8.png)

- 추가 후 관리자페이지 내 `회원관리` 메뉴 탭 테이블

![Screenshot 2023-01-03 at 10 39 15 PM](https://user-images.githubusercontent.com/56868605/210368276-75f715eb-07d9-4fae-a303-8a08bab5cd66.png)
![ezgif com-gif-maker (32)](https://user-images.githubusercontent.com/56868605/210368031-4d8fa576-941f-4c73-86cc-671a99e1b84d.gif)

- 수정 후 메인페이지 내 공지사항 테이블 디자인

![Screenshot 2023-01-03 at 10 38 30 PM](https://user-images.githubusercontent.com/56868605/210368110-1c20bddf-6da0-402f-bf60-75f9ce8b9b4c.png)