### PR TITLE
[feat]: 게시글 페이지에서 '뒤로가기' 기능 사용 시 Pagination 번호 유지 기능 추가 (#251)

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -67,7 +67,7 @@ function App() {
         <Routes>
           <Route path="/" element={<MainPage />} />
           <Route path="/awards" element={<AwardsPage />} />
-          <Route path="/exam" element={<ExamPage />} />
+          <Route path="/exam" element={<ExamPage pageNum={1} />} />
           <Route
             path="/exam/examUpdate"
             element={
@@ -85,7 +85,7 @@ function App() {
             }
           />
 
-          <Route path="/project" element={<ProjectPage />} />
+          <Route path="/project" element={<ProjectPage pageNum={1} />} />
           <Route
             path="/project/projectUpdate"
             element={
@@ -103,7 +103,7 @@ function App() {
             }
           />
 
-          <Route path="/seminar" element={<SeminarPage />} />
+          <Route path="/seminar" element={<SeminarPage pageNum={1} />} />
           <Route
             path="/seminar/seminarUpdate"
             element={
@@ -121,7 +121,7 @@ function App() {
             }
           />
 
-          <Route path="/photo" element={<PhotoPage />} />
+          <Route path="/photo" element={<PhotoPage pageNum={1} />} />
           <Route
             path="/photo/photoUpdate"
             element={
@@ -139,7 +139,7 @@ function App() {
             }
           />
 
-          <Route path="/notice" element={<NoticePage />} />
+          <Route path="/notice" element={<NoticePage pageNum={1} />} />
           <Route
             path="/noticeDetail"
             element={
@@ -157,7 +157,7 @@ function App() {
             }
           />
 
-          <Route path="/report" element={<ReportPage />} />
+          <Route path="/report" element={<ReportPage pageNum={1} />} />
           <Route
             path="/report/reportUpdate"
             element={
@@ -175,7 +175,7 @@ function App() {
             }
           />
 
-          <Route path="/freeBoard" element={<FreeBoardPage />} />
+          <Route path="/freeBoard" element={<FreeBoardPage pageNum={1} />} />
           <Route
             path="/freeBoard/freeBoardUpdate"
             element={

--- a/src/pages/exam/ExamDetailPage.jsx
+++ b/src/pages/exam/ExamDetailPage.jsx
@@ -5,20 +5,42 @@ import Comment from "../../components/Comment";
 import "./ExamDetail.scss";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
+import { createBrowserHistory } from "history";
 
 function ExamDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/exam", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="ExamDetail">
@@ -90,7 +112,11 @@ function ExamDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/exam");
+                navigate("/exam", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/exam/ExamPage.jsx
+++ b/src/pages/exam/ExamPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
 import exam from "../../imgs/banner/exam.jpg";
 import {
@@ -10,12 +10,13 @@ import {
 } from "../../hooks/boardServices";
 import { myRole } from "../../hooks/useAuth";
 
-function ExamPage() {
+function ExamPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -24,7 +25,7 @@ function ExamPage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -45,6 +46,10 @@ function ExamPage() {
     else if (pageNum % 10 === 0) setPageList(pageNum - 9);
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
+
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
 
   const examUpload = () => {
     navigate("./examUpdate");
@@ -69,6 +74,7 @@ function ExamPage() {
           state: {
             boardId,
             articleId: list.id,
+            pageNum,
           },
         });
       }

--- a/src/pages/freeBoard/FreeBoardDetailPage.jsx
+++ b/src/pages/freeBoard/FreeBoardDetailPage.jsx
@@ -5,20 +5,42 @@ import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
+import { createBrowserHistory } from "history";
 
 function FreeBoardDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/freeBoard", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="FreeBoardDetail">
@@ -90,7 +112,11 @@ function FreeBoardDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/freeBoard");
+                navigate("/freeBoard", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/freeBoard/FreeBoardPage.jsx
+++ b/src/pages/freeBoard/FreeBoardPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import free from "../../imgs/banner/free.jpg";
 import {
   getArticleList,
@@ -9,12 +9,13 @@ import {
 } from "../../hooks/boardServices";
 import { myRole } from "../../hooks/useAuth";
 
-function FreeBoardPage() {
+function FreeBoardPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -23,7 +24,7 @@ function FreeBoardPage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -45,6 +46,10 @@ function FreeBoardPage() {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const freeBoardUpload = () => {
     navigate("./freeBoardUpdate");
   };
@@ -54,6 +59,7 @@ function FreeBoardPage() {
       state: {
         boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };

--- a/src/pages/notice/NoticeDetailPage.jsx
+++ b/src/pages/notice/NoticeDetailPage.jsx
@@ -5,20 +5,43 @@ import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
+import { createBrowserHistory } from "history";
 
 function NoticeDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
+
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/notice", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="NoticeDetail">
@@ -89,7 +112,11 @@ function NoticeDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/notice");
+                navigate("/notice", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/notice/NoticePage.jsx
+++ b/src/pages/notice/NoticePage.jsx
@@ -1,7 +1,7 @@
 import "./NoticePage.scss";
 import { Pagination } from "react-bootstrap";
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import notice from "../../imgs/banner/notice.jpg";
 import {
   getArticleList,
@@ -10,12 +10,13 @@ import {
 } from "../../hooks/boardServices";
 import { myRole } from "../../hooks/useAuth";
 
-function NoticePage() {
+function NoticePage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -24,7 +25,7 @@ function NoticePage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -46,6 +47,10 @@ function NoticePage() {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const onClickRegister = () => {
     navigate("/notice/noticeUpdate");
   };
@@ -55,6 +60,7 @@ function NoticePage() {
       state: {
         boardId: boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };

--- a/src/pages/photo/PhotoDetail.jsx
+++ b/src/pages/photo/PhotoDetail.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-
 import "./PhotoDetail.scss";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
@@ -8,17 +7,21 @@ import "swiper/css/pagination";
 import "swiper/css/navigation";
 import Swal from "sweetalert2";
 import Comment from "../../components/Comment";
-
 import { Navigation } from "swiper";
 import api from "../../utils/api";
 import { deletePost } from "../../hooks/usePostServices";
+import { createBrowserHistory } from "history";
+
 const PhotoDetail = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [createDt, setCreateDt] = useState("");
   const [mainImg, setMainImg] = useState("");
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     api
@@ -30,6 +33,7 @@ const PhotoDetail = () => {
       )
       .then((response) => {
         if (response.data.success) {
+          setPageNum(location.state.pageNum);
           setArticle(response.data.response);
           setMainImg(response.data.response.files[0].filePath);
           setLoading(true);
@@ -42,6 +46,24 @@ const PhotoDetail = () => {
         }
       });
   }, [location.state.boardId, location.state.articleId]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/photo", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
+
   return (
     <div className="photo-detail-content pt-5">
       {loading ? (
@@ -142,10 +164,14 @@ const PhotoDetail = () => {
                 padding: "10px 0px 10px 0px",
               }}
               onClick={() => {
-                navigate("../photo");
+                navigate("/photo", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
-              글 목록
+              목록
             </button>
           </div>
         </div>

--- a/src/pages/photo/PhotoList.jsx
+++ b/src/pages/photo/PhotoList.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { Row, Col, Pagination } from "react-bootstrap";
 import "./PhotoList.scss";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { getArticleList, getBoardList } from "../../hooks/boardServices";
 import { myRole } from "../../hooks/useAuth";
 
-const PhotoList = () => {
+const PhotoList = (props) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [photoList, setPhotoList] = useState({});
   const [loading, setloading] = useState(false);
   const [boardId, setBoardid] = useState();
@@ -16,7 +17,7 @@ const PhotoList = () => {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -38,11 +39,16 @@ const PhotoList = () => {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const onClickDetail = (list) => {
     navigate("./photoDetail", {
       state: {
         boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };

--- a/src/pages/photo/PhotoPage.jsx
+++ b/src/pages/photo/PhotoPage.jsx
@@ -4,7 +4,7 @@ import PhotoList from "./PhotoList";
 import { useNavigate } from "react-router-dom";
 import photo from "../../imgs/banner/photo.jpg";
 
-function PhotoPage() {
+function PhotoPage(props) {
   const navigate = useNavigate();
 
   const photoUpload = () => {
@@ -40,7 +40,7 @@ function PhotoPage() {
           글쓰기
         </button>
       </div>
-      <PhotoList />
+      <PhotoList pageNum={props.pageNum} />
     </div>
   );
 }

--- a/src/pages/report/ReportDetailPage.jsx
+++ b/src/pages/report/ReportDetailPage.jsx
@@ -6,20 +6,43 @@ import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
+import { myRole } from "../../hooks/useAuth";
+import { createBrowserHistory } from "history";
 
 function ReportDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/report", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="ReportDetail">
@@ -91,7 +114,11 @@ function ReportDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/report");
+                navigate("/report", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/report/ReportPage.jsx
+++ b/src/pages/report/ReportPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import report from "../../imgs/banner/report.jpg";
 import {
   getArticleList,
@@ -9,12 +9,13 @@ import {
 } from "../../hooks/boardServices";
 import { myRole } from "../../hooks/useAuth";
 
-function ReportPage() {
+function ReportPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -23,7 +24,7 @@ function ReportPage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -45,6 +46,10 @@ function ReportPage() {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const reportUpload = () => {
     navigate("./reportUpdate");
   };
@@ -54,6 +59,7 @@ function ReportPage() {
       state: {
         boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };

--- a/src/pages/seminar/SeminarDetailPage.jsx
+++ b/src/pages/seminar/SeminarDetailPage.jsx
@@ -5,20 +5,42 @@ import { getBoards } from "../../hooks/boardServices";
 import Comment from "../../components/Comment";
 import { deletePost } from "../../hooks/usePostServices";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
+import { createBrowserHistory } from "history";
 
 function SeminarDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/seminar", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="SeminarDetail">
@@ -90,7 +112,11 @@ function SeminarDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/seminar");
+                navigate("/seminar", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/seminar/SeminarPage.jsx
+++ b/src/pages/seminar/SeminarPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   getArticleList,
   getBoardList,
@@ -9,12 +9,13 @@ import {
 import seminar from "../../imgs/banner/seminar.jpg";
 import { myRole } from "../../hooks/useAuth";
 
-function SeminarPage() {
+function SeminarPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -23,7 +24,7 @@ function SeminarPage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -45,6 +46,10 @@ function SeminarPage() {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const seminarUpload = () => {
     navigate("./seminarUpdate");
   };
@@ -54,6 +59,7 @@ function SeminarPage() {
       state: {
         boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };

--- a/src/pages/subProject/ProjectDetailPage.jsx
+++ b/src/pages/subProject/ProjectDetailPage.jsx
@@ -5,20 +5,42 @@ import Comment from "../../components/Comment";
 import "./ProjectDetail.scss";
 import { UploadedFilesInArticle } from "../../components/UploadedFilesInArticle";
 import { deletePost } from "../../hooks/usePostServices";
+import { createBrowserHistory } from "history";
 
 function ProjectDetailPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const history = createBrowserHistory();
   const [article, setArticle] = useState({});
   const [loading, setLoading] = useState(false);
   const [like, setLike] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [locationKeys, setLocationKeys] = useState([]);
 
   useEffect(() => {
     getBoards(location).then((data) => {
+      setPageNum(location.state.pageNum);
       setArticle(data.data.response);
       setLoading(true);
     });
   }, [location]);
+
+  // 페이지 '뒤로가기'를 감지하는 코드
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        navigate("/project", {
+          state: {
+            pageNum,
+          },
+        });
+      }
+    });
+  }, [locationKeys, history]);
 
   return (
     <div className="ProjectDetail">
@@ -90,7 +112,11 @@ function ProjectDetailPage() {
             <button
               className="grey darken-3"
               onClick={() => {
-                navigate("/exam");
+                navigate("/project", {
+                  state: {
+                    pageNum,
+                  },
+                });
               }}
             >
               목록

--- a/src/pages/subProject/ProjectPage.jsx
+++ b/src/pages/subProject/ProjectPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Pagination } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import project from "../../imgs/banner/project.jpg";
 import { myRole } from "../../hooks/useAuth";
 import {
@@ -9,12 +9,13 @@ import {
   searchArticles,
 } from "../../hooks/boardServices";
 
-function ProjectPage() {
+function ProjectPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [boardList, setBoardList] = useState({});
   const [loading, setLoading] = useState(false);
   const [boardId, setBoardId] = useState();
-  const [pageNum, setPageNum] = useState(1);
+  const [pageNum, setPageNum] = useState(props.pageNum);
   const [pageList, setPageList] = useState(1);
   const [keywordSelectOption, setKeywordSelectOption] =
     useState("ARTICLE_TITLE");
@@ -23,7 +24,7 @@ function ProjectPage() {
   useEffect(() => {
     // 비회원의 권한 확인
     myRole().then((response) => {
-      if (response != undefined) {
+      if (response !== undefined) {
         getBoardList().then((response) => {
           if (response.data.success) {
             response.data.response.forEach((res) => {
@@ -45,6 +46,10 @@ function ProjectPage() {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
+  useEffect(() => {
+    location.state && setPageNum(location.state.pageNum);
+  }, [location]);
+
   const examUpload = () => {
     navigate("./projectUpdate");
   };
@@ -54,6 +59,7 @@ function ProjectPage() {
       state: {
         boardId,
         articleId: list.id,
+        pageNum,
       },
     });
   };


### PR DESCRIPTION
## 👀 이슈

resolve #251 

## 📌 개요

현재 홈페이지에서 게시글 열람 후 웹 브라우저의 뒤로가기 기능 사용 시
해당 페이지에 접근하기 이전 pagination 번호를 별도로 저장해 두지 않아
다시 1페이지로 초기화되는 불편함이 있어 해당 문제를 제거하고자 pagination 번호
유지 기능을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- 게시글 내에서 `뒤로가기` 기능 사용 시 이전 게시글 pagination 번호가 유지되도록
게시글 컴포넌트 내에서 `뒤로가기 기능 감지 이벤트` 코드를 추가하여 해당 기능을 구현하였습니다.
- 게시글 내 하단에 `목록`버튼 클릭 시 이전 게시글 pagination 번호가 유지되도록 코드를 추가하였습니다.

## ✅ 참고 사항

- 이전의 불편 사항 시연

![ezgif com-gif-maker (33)](https://user-images.githubusercontent.com/56868605/210722740-209f492f-77f3-439b-8bd9-ce3a47217586.gif)

- 기능 추가 후

![ezgif com-gif-maker (34)](https://user-images.githubusercontent.com/56868605/210818606-aff57cc9-a897-4e7e-8dee-66624940ec4c.gif)