### PR TITLE
[fix]: 임시 비밀번호 생성 API 사용 관련 Alert 표시 로직 변경 (#254)

### DIFF
--- a/src/pages/findUser/FindUserPage.jsx
+++ b/src/pages/findUser/FindUserPage.jsx
@@ -14,53 +14,59 @@ function FindUserPage() {
     findCheck.setAttribute("disabled", true);
     findCheck.innerText = "확인 중...";
     try {
-      await api
-        .post("/auth/tempPassword?userEmail=" + email)
-        .then((response) => {
-          if (response.data.success) {
-            Swal.fire({
-              icon: "success",
-              title: "해당 이메일에 임시 비밀번호를 전송했습니다.",
-            }).then((result) => {
-              if (result.isConfirmed) {
-                navigate("/");
-              }
-            });
-          } else {
-            Swal.fire({
-              icon: "error",
-              title: "해당 회원은 존재하지 않습니다.",
-            }).then((result) => {
-              if (result) {
-                findCheck.removeAttribute("disabled");
-                findCheck.innerText = "확인";
-              }
-            });
-          }
-        });
+      await api.post("/tempPassword?userEmail=" + email).then((response) => {
+        if (response.data.success) {
+          Swal.fire({
+            icon: "success",
+            title: "해당 이메일로 임시 비밀번호를 전송했습니다.",
+          }).then((result) => {
+            if (result.isConfirmed) {
+              navigate("/");
+            }
+          });
+        }
+      });
     } catch (error) {
-      if (error.response.status === 400) {
-        Swal.fire({
-          icon: "error",
-          title:
-            error.response.data.apiError.message.substring(
-              0,
-              error.response.data.apiError.message.indexOf("!")
-            ) + ".",
-        }).then((result) => {
-          if (result) {
+      switch (error.response.status) {
+        case 400: {
+          Swal.fire({
+            icon: "error",
+            title:
+              error.response.data.apiError.message.substring(
+                0,
+                error.response.data.apiError.message.indexOf("!")
+              ) + ".",
+          }).then((result) => {
+            if (result) {
+              findCheck.removeAttribute("disabled");
+              findCheck.innerText = "확인";
+            }
+          });
+          break;
+        }
+
+        case 404: {
+          Swal.fire({
+            icon: "error",
+            title: "입력하신 이메일의 회원을\n찾을 수 없습니다.",
+          }).then((result) => {
+            if (result) {
+              findCheck.removeAttribute("disabled");
+              findCheck.innerText = "확인";
+            }
+          });
+          break;
+        }
+
+        default: {
+          Swal.fire({
+            icon: "error",
+            title: "예기치 못 한 에러가 발생하였습니다.",
+          }).then((result) => {
             findCheck.removeAttribute("disabled");
             findCheck.innerText = "확인";
-          }
-        });
-      } else {
-        Swal.fire({
-          icon: "error",
-          title: "예기치 못 한 에러가 발생하였습니다.",
-        }).then((result) => {
-          findCheck.removeAttribute("disabled");
-          findCheck.innerText = "확인";
-        });
+          });
+        }
       }
     }
   };


### PR DESCRIPTION
## 👀 이슈

resolve #254 

## 📌 개요

현재 홈페이지에서 회원가입한 이력이 있는 사용자가 본인의
비밀번호를 분실한 경우 `비밀번호 찾기` 기능을 통하여 input 창에
입력한 이메일에 해당하는 계정에 새로운 비밀번호를 부여해 주는데, 만일
DB에 존재하지 않는 이메일을 입력하여 API를 사용하려는 경우에는
`해당 회원은 존재하지 않습니다.` 라는 Alert를 띄워주지만, 해당 로직이
`http response`의 실패 여부에 따라서 나타나도록 코드가 설계되어 있어
`존재하지 않는 이메일` 에러 외의 에러는 별도로 구분할 수가 없어 해당
문제 방지하고자 상황에 따른 에러를 구분할 수 있도록 `http response status code`를
기반으로 Alert가 나타나도록 로직을 수정하였습니다.

## 👩‍💻 작업 사항

- `FindUserPage.jsx` 코드 내 `해당 회원은 존재하지 않습니다.` 에러 Alert를 `http response status code`를 기준으로 나타날 수 있도록 코드를 수정합니다.

## ✅ 참고 사항

- 기존 로직

![Screenshot 2023-01-09 at 11 05 43 AM](https://user-images.githubusercontent.com/56868605/211233026-ef7debde-51c8-40cc-b26b-1bd7653a814e.png)

- 수정 후 로직

![Screenshot 2023-01-10 at 12 05 41 PM](https://user-images.githubusercontent.com/56868605/211452766-7bc2e6ff-7142-4dd2-a174-e9b6d56774b4.png)

---

![before](https://user-images.githubusercontent.com/56868605/211452798-9db72bba-8342-407e-ab1a-14fbf1b9ba3d.png)

![after](https://user-images.githubusercontent.com/56868605/211452822-f8cd41be-83f5-4215-b387-26bb20dd961b.png)