### PR TITLE
[fix]: 게시글 내용 슬라이드 바 제거 (#260)

### DIFF
--- a/src/pages/exam/ExamDetail.scss
+++ b/src/pages/exam/ExamDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/exam/ExamDetailPage.jsx
+++ b/src/pages/exam/ExamDetailPage.jsx
@@ -63,7 +63,7 @@ function ExamDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/freeBoard/FreeBoardDetail.scss
+++ b/src/pages/freeBoard/FreeBoardDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/freeBoard/FreeBoardDetailPage.jsx
+++ b/src/pages/freeBoard/FreeBoardDetailPage.jsx
@@ -63,7 +63,7 @@ function FreeBoardDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/notice/NoticeDetail.scss
+++ b/src/pages/notice/NoticeDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/notice/NoticeDetailPage.jsx
+++ b/src/pages/notice/NoticeDetailPage.jsx
@@ -64,7 +64,7 @@ function NoticeDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/notice/NoticePage.jsx
+++ b/src/pages/notice/NoticePage.jsx
@@ -47,8 +47,6 @@ function NoticePage(props) {
     else setPageList(parseInt(pageNum / 10) * 10 + 1);
   }, [pageNum]);
 
-  console.log(boardList);
-
   useEffect(() => {
     location.state && setPageNum(location.state.pageNum);
   }, [location]);

--- a/src/pages/photo/PhotoDetail.jsx
+++ b/src/pages/photo/PhotoDetail.jsx
@@ -139,7 +139,7 @@ const PhotoDetail = () => {
           </div>
           <hr />
 
-          <pre>{article.content}</pre>
+          <span className="articleContent">{article.content}</span>
           <Comment
             boardId={location.state.boardId}
             articleId={location.state.articleId}

--- a/src/pages/photo/PhotoDetail.scss
+++ b/src/pages/photo/PhotoDetail.scss
@@ -4,8 +4,13 @@
   .slide {
     padding: 0px 20px;
   }
-  button{
+  button {
     width: 130px;
     padding: 10px 0px;
+  }
+
+  .articleContent {
+    word-break: break-all;
+    white-space: pre-line;
   }
 }

--- a/src/pages/report/ReportDetail.scss
+++ b/src/pages/report/ReportDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/report/ReportDetailPage.jsx
+++ b/src/pages/report/ReportDetailPage.jsx
@@ -65,7 +65,7 @@ function ReportDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/seminar/SeminarDetail.scss
+++ b/src/pages/seminar/SeminarDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/seminar/SeminarDetailPage.jsx
+++ b/src/pages/seminar/SeminarDetailPage.jsx
@@ -63,7 +63,7 @@ function SeminarDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"

--- a/src/pages/subProject/ProjectDetail.scss
+++ b/src/pages/subProject/ProjectDetail.scss
@@ -54,6 +54,10 @@
 
   .contents {
     padding: 5% 0px 1% 0px;
+    > span {
+      word-break: break-all;
+      white-space: pre-line;
+    }
     .contentsBottom {
       margin: 8% auto 1%;
       text-align: center;

--- a/src/pages/subProject/ProjectDetailPage.jsx
+++ b/src/pages/subProject/ProjectDetailPage.jsx
@@ -63,7 +63,7 @@ function ProjectDetailPage() {
           </div>
 
           <div className="contents">
-            <pre>{article.content}</pre>
+            <span>{article.content}</span>
             <div className="contentsBottom">
               <span
                 className="text-center text-white like"


### PR DESCRIPTION
## 👀 이슈

resolve #260 

## 📌 개요

현재 게시글 내에서 글의 내용이 한 줄로 길 경우에는 줄바꿈이 이뤄지지 않고
슬라이드 바가 생겨 작성한 텍스트를 확인하도록 되어 있는데, 이런 경우에는
자동으로 줄바꿈이 되도록 하여 사용자가 별도의 슬라이딩 없이 텍스트를 한 화면
내에서 확인할 수 있도록 글 내용 UI 요소 스타일링 코드를 수정하였습니다.

## 👩‍💻 작업 사항

- 게시글 관련 컴포넌트 내 게시글 내용 요소 태그 수정(**`pre`** -> **`span`**)
- 게시글 관련 컴포넌트 전용 SCSS 파일 스타일링 코드 수정

## ✅ 참고 사항

- 이전 페이지 (**`GIF`** 파일 첨부)

![ezgif com-gif-maker (36)](https://user-images.githubusercontent.com/56868605/213924540-3e1c56c8-8548-4800-be28-5d9548a6167b.gif)

- 수정 후 페이지 (Enter 키 입력 없이 한 줄로 긴 텍스트 입력 시에도 자동 개행이 적용됨)
<img width="1305" alt="Screenshot 2023-01-23 at 12 55 23 AM" src="https://user-images.githubusercontent.com/56868605/213925506-69447065-fead-41d8-9ab0-023824764977.png">

