### PR TITLE
[bug]: 클라이언트 코드 내 (임시 비밀번호 생성 API) URL 올바르게 수정 (#266)

### DIFF
--- a/src/pages/findUser/FindUserPage.jsx
+++ b/src/pages/findUser/FindUserPage.jsx
@@ -14,18 +14,20 @@ function FindUserPage() {
     findCheck.setAttribute("disabled", true);
     findCheck.innerText = "확인 중...";
     try {
-      await api.post("/tempPassword?userEmail=" + email).then((response) => {
-        if (response.data.success) {
-          Swal.fire({
-            icon: "success",
-            title: "해당 이메일로 임시 비밀번호를 전송했습니다.",
-          }).then((result) => {
-            if (result.isConfirmed) {
-              navigate("/");
-            }
-          });
-        }
-      });
+      await api
+        .post("/auth/tempPassword?userEmail=" + email)
+        .then((response) => {
+          if (response.data.success) {
+            Swal.fire({
+              icon: "success",
+              title: "해당 이메일로 임시 비밀번호를 전송했습니다.",
+            }).then((result) => {
+              if (result.isConfirmed) {
+                navigate("/");
+              }
+            });
+          }
+        });
     } catch (error) {
       switch (error.response.status) {
         case 400: {


### PR DESCRIPTION
## 👀 이슈

resolve #266 

## 📌 개요

현재 `임시 비밀번호 생성 API`를 사용하려면 `/auth/tempPassword` URL으로
HTTP request를 진행하여야 하는데, #254 이슈 작업 중 **`8159db6(commit ID)`**
> [[FIX] 임시 비밀번호 생성 API 사용 관련 Alert 표시 로직 변경 #254](https://github.com/SAMMaru5/SAMMaruClient/pull/255/commits/0928d5ddb8d6fe294e83e5aa7e9960a8abb233f7)

올바르지 않은 URL작성으로 인하여 해당 API 사용이 불가했던 버그가 발견되어
수정하였습니다.

## 👩‍💻 작업 사항

- `src/pages/findUser/FindUserPage.jsx` 파일 내 17번 째 코드 라인 (`/tempPassword?userEmail...`)
```javascript
await api.post("/tempPassword?userEmail=" + email).then((response) => {
```

## ✅ 참고 사항

- 버그 수정 후(`임시 비밀번호 생성 API` 정상적으로 사용 가능)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/56868605/217439901-3265025a-b0eb-4a04-8fef-e18a212b6cb9.gif)