### PR TITLE
[bug]: 만료된 JWT 토큰을 이용한 API 사용으로 인해 발생하는 버그 제거 (#274)

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { signout } from "../hooks/useAuth";
 
 const instance = axios.create({
   withCredentials: true,
@@ -6,7 +7,7 @@ const instance = axios.create({
 });
 
 instance.interceptors.request.use(async function (config) {
-  const currentTime = new Date();
+  const currentTime = new Date().getTime();
   const accessToken = localStorage.getItem("sm-accessToken");
   const refreshToken = localStorage.getItem("sm-refreshToken");
 
@@ -17,20 +18,36 @@ instance.interceptors.request.use(async function (config) {
 
   if (localStorage.getItem("sm-expired")) {
     const expiredTime = new Date(
-        localStorage.getItem("sm-expired").toString().substring(0, 19)
-    );
+      localStorage.getItem("sm-expired").toString().substring(0, 19)
+    ).getTime();
 
-    if (expiredTime.getTime() - currentTime.getTime() <= 300000) {
+    // 만료 시간 이후에 API의 호출이 일어난 경우 로컬 스토리지 초기화
+    if (expiredTime < currentTime) {
+      localStorage.clear();
+      return config;
+    }
+
+    // 만료 시간 2분 내에 API의 호출이 일어나면 리이슈 요청
+    if (expiredTime - currentTime <= 120000) {
       await axios
-        .post(
-          process.env.REACT_APP_URL + "/auth/reissue",
-          {accessToken, refreshToken}
-        )
+        .post(process.env.REACT_APP_URL + "/auth/reissue", {
+          accessToken,
+          refreshToken,
+        })
         .then((res) => {
-          if(res.status === 200){
-            localStorage.setItem('sm-accessToken', res.data.response.accessToken);
-            localStorage.setItem('sm-refreshToken', res.data.response.refreshToken);
-            localStorage.setItem('sm-expired', res.data.response.accessTokenExpiresTime);
+          if (res.status === 200) {
+            localStorage.setItem(
+              "sm-accessToken",
+              res.data.response.accessToken
+            );
+            localStorage.setItem(
+              "sm-refreshToken",
+              res.data.response.refreshToken
+            );
+            localStorage.setItem(
+              "sm-expired",
+              res.data.response.accessTokenExpiresTime
+            );
           }
         });
     }
@@ -39,11 +56,8 @@ instance.interceptors.request.use(async function (config) {
   return config;
 });
 
-instance.interceptors.response.use(
-    (response) => {
-      return response;
-    },
-);
-
+instance.interceptors.response.use((response) => {
+  return response;
+});
 
 export default instance;


### PR DESCRIPTION
## 👀 이슈

resolve #274 

## 📌 개요

로그인 이후에 발급된 JWT accesstoken의 만료시간이 지난 후에 웹 브라우저
localstorage의 데이터들이 초기화되지 않고 그대로 남아 만료된 accesstoken을
사용하여 API를 사용하는 상황으로 인하여 버그가 발생하여, accesstoken의 만료 시간
2분 전에 API 호출이 발생하면 reissue API를 이용하여 accesstoken을 새롭게 발급받고,
만료 시간 이후에 API 호출이 일어났을 때에는 웹 브라우저 localstorage가 초기화되도록
하였습니다.

## 👩‍💻 작업 사항

- accesstoken 만료시간 2분 전에 API 호출이 일어나면 reissue 요청
- accesstoken 만료시간 이후에 API 호출이 일어나면 웹 브라우저 localstorage 초기화

## ✅ 참고 사항

- 문제 예시

<img width="1035" alt="Screenshot 2023-02-09 at 11 09 29 PM" src="https://user-images.githubusercontent.com/56868605/217842793-08b3a62b-f123-4240-9963-71a21de75ee5.png">
