### PR TITLE
[fix]: 게시글 상세 컴포넌트 내에서 reissue 발생 후 로그인 페이지로 이동되는 현상 수정 및 불필요 console.log 메서드 제거 (#276)

### DIFF
--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -117,7 +117,6 @@ function Comment(props) {
               getComments();
             });
         } catch (error) {
-          console.log(error);
           return Swal.fire({
             icon: "error",
             title: "댓글 삭제 중 오류가 발생하였습니다.",

--- a/src/hooks/usePostServices.js
+++ b/src/hooks/usePostServices.js
@@ -19,7 +19,6 @@ export const deletePost = (props) => {
             });
           });
       } catch (error) {
-        console.log(error);
         return Swal.fire({
           icon: "error",
           title: "게시글이 삭제 중 오류가 발생하였습니다.",

--- a/src/pages/management/MemberManage.jsx
+++ b/src/pages/management/MemberManage.jsx
@@ -171,11 +171,6 @@ function MemberManage() {
                 icon: "error",
                 title: "예기치 못 한 에러가 발생하였습니다.",
               });
-              console.log(
-                "🚀 ~ file: MemberManage.jsx:177 ~ checkExpiredAccesstoken ~ error",
-                error
-              );
-              // window.location.href = "/login";
             }
           }
         } else {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { signout } from "../hooks/useAuth";
+import Swal from "sweetalert2";
 
 const instance = axios.create({
   withCredentials: true,
@@ -48,6 +48,18 @@ instance.interceptors.request.use(async function (config) {
               "sm-expired",
               res.data.response.accessTokenExpiresTime
             );
+          }
+        })
+        .catch((error) => {
+          switch (error.response.status) {
+            case 401:
+              window.location.reload();
+              break;
+            default:
+              Swal.fire({
+                icon: "error",
+                title: "예기치 못 한 에러가 발생하였습니다.",
+              });
           }
         });
     }


### PR DESCRIPTION
## 👀 이슈

resolve #276 

## 📌 개요

#275 이슈 작업 이후에 기능 테스트 중 게시글 상세 컴포넌트 내에서 `accessstoken` 만료시간 이전에(만료 2분 전)  `reissue` 요청이
일어나면, 새롭게 발급된 accesstoken으로 게시글 상세 정보를 불러오는 것이 아닌, 이전에 만료되었던 accesstoken을 기반으로
API 호출이 일어나 에러가 발생하고, 로그인 페이지로 넘어가는 문제가 있었습니다. 추가적으로, 현재 프로젝트에서 불필요하게 사용되는 `console.log` 메서드를 일괄적으로 제거하고자 하였습니다.

## 👩‍💻 작업 사항

- 인터셉터 내부 reissue API 호출에 대한 예외처리 코드 추가
- `console.log` 메소드가 사용되는 파일 내부 해당 메서드 제거

## ✅ 참고 사항

- 수정이 필요한 현상

https://user-images.githubusercontent.com/56868605/218242617-8f1e57ee-8c51-488d-bde8-86309382c391.mov

- reissue가 여러 번 발생함
>  <img width="842" alt="Screenshot 2023-02-11 at 2 50 37 PM" src="https://user-images.githubusercontent.com/56868605/218242868-f5661aa2-2fa0-4ed0-a3de-9116875f52af.png">

- 해결 후 (로그인 페이지로 이동되지 않음)

https://user-images.githubusercontent.com/56868605/218245491-e853b875-9500-4b5a-86bd-9afa54208e20.mov