### PR TITLE
[fix]: JWT 인증 방식 변경에 따른 interceptor 코드 수정 (#278)

### DIFF
--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -33,10 +33,6 @@ function LoginPage() {
             response.data.response.accessToken
           );
           localStorage.setItem(
-            "sm-refreshToken",
-            response.data.response.refreshToken
-          );
-          localStorage.setItem(
             "sm-expired",
             response.data.response.accessTokenExpiresTime
           );

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -7,9 +7,8 @@ const instance = axios.create({
 });
 
 instance.interceptors.request.use(async function (config) {
-  const currentTime = new Date().getTime();
   const accessToken = localStorage.getItem("sm-accessToken");
-  const refreshToken = localStorage.getItem("sm-refreshToken");
+  const currentTime = new Date().getTime();
 
   config.headers = {
     Authorization: `Bearer ${accessToken}`,
@@ -30,23 +29,20 @@ instance.interceptors.request.use(async function (config) {
     // 만료 시간 2분 내에 API의 호출이 일어나면 리이슈 요청
     if (expiredTime - currentTime <= 120000) {
       await axios
-        .post(process.env.REACT_APP_URL + "/auth/reissue", {
-          accessToken,
-          refreshToken,
-        })
-        .then((res) => {
-          if (res.status === 200) {
+        .post(
+          process.env.REACT_APP_URL + "/auth/reissue",
+          { accessToken },
+          { withCredentials: true }
+        )
+        .then((response) => {
+          if (response.status === 200) {
             localStorage.setItem(
               "sm-accessToken",
-              res.data.response.accessToken
-            );
-            localStorage.setItem(
-              "sm-refreshToken",
-              res.data.response.refreshToken
+              response.data.response.accessToken
             );
             localStorage.setItem(
               "sm-expired",
-              res.data.response.accessTokenExpiresTime
+              response.data.response.accessTokenExpiresTime
             );
           }
         })


### PR DESCRIPTION
## 👀 이슈

resolve #278 

## 📌 개요

홈페이지 내에서 로그인 시 서버로부터 `accesstoken`, `refreshtoken`, `accessTokenExpiresTime`을 받아와
로컬 스토리지 공간에 저장하여 별도로 관리하였는데, refreshtoken을 쿠키에 보내는 방법으로 변경됨에 따라 프론트
interceptor 코드를 일부 수정하고자 하였습니다.

## 👩‍💻 작업 사항

- `src/utils/api.js` 파일 내 **request interceptor** 정의 코드 내부 `reissue` API 호출 시 기존 refreshtoken 관련 코드 제거 및 `withCredentials` 옵션 `true`로 설정
- `login` API 호출 시 HTTP response, `refreshtoken`이 없어짐에 따라 `localstorage` 내 `refreshtoken` 값을 저장하는
코드 제거

## ✅ 참고 사항

- 적용 환경 (만료시간 2분 전 새로고침[+ 다른 API 호출 시]을 하여 `reissue` API가 요청되고 클라이언트 측 `localstorage`의 `accesstoken` 및 `만료시간`이 정상적으로 갱신됨)

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/56868605/219036306-45901655-2c45-413f-8d45-fcb793b5f08b.gif)