### PR TITLE
[feat]: 관리자 페이지 내 회원정보 수정 UI 요소 추가 (#280)

### DIFF
--- a/src/pages/management/MemberManage.jsx
+++ b/src/pages/management/MemberManage.jsx
@@ -156,6 +156,21 @@ function MemberManage() {
     email,
     generation
   ) => {
+    if (
+      username === "" ||
+      studentId === "" ||
+      email === "" ||
+      generation === null
+    ) {
+      Swal.fire({
+        title: "모든 정보를 입력해 주세요",
+        icon: "warning",
+        confirmButtonColor: "#a7a7a7",
+        confirmButtonText: "닫기",
+      });
+      return;
+    }
+
     checkExpiredAccesstoken().then((response) => {
       Swal.fire({
         icon: "info",
@@ -179,6 +194,7 @@ function MemberManage() {
               .then((result) => {
                 searchAllUsers();
                 Swal.fire({
+                  confirmButtonColor: "#4880ee",
                   icon: "success",
                   title: `정상적으로 변경되었습니다.`,
                 });
@@ -305,9 +321,21 @@ function MemberManage() {
                       <td>
                         <input
                           type="number"
-                          value={member.generation}
+                          value={"" + member.generation}
                           onChange={(e) => {
                             if (e.target.value < 0) e.target.value = 0;
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    generation: e.target.value,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
                           }}
                           style={{
                             height: "1.5rem",

--- a/src/pages/management/MemberManage.jsx
+++ b/src/pages/management/MemberManage.jsx
@@ -8,12 +8,21 @@ import { checkExpiredAccesstoken } from "../../hooks/useAuth";
 function MemberManage() {
   const [members, setMembers] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [name, setName] = useState("");
+  const [searchName, setSearchName] = useState("");
 
   const searchAllUsers = () => {
+    setMembers([]);
     api.get("/api/users/info").then((response) => {
       if (response.data.success) {
-        setMembers(response.data.response);
+        response.data.response.map((eachMemberInfo, idx) => {
+          setMembers((prevMembers) => [
+            ...prevMembers,
+            {
+              ...eachMemberInfo,
+              userInfoModifyMode: false,
+            },
+          ]);
+        });
         setLoading(true);
       }
     });
@@ -78,16 +87,16 @@ function MemberManage() {
     e.preventDefault();
     checkExpiredAccesstoken().then((response) => {
       if (response) {
-        if (name === "") {
+        if (searchName === "") {
           searchAllUsers();
         } else {
-          api.get("/api/users/detail?username=" + name).then((result) => {
+          api.get("/api/users/detail?username=" + searchName).then((result) => {
             if (result.data.success) {
               setMembers(result.data.response);
             } else {
               Swal.fire({
                 icon: "info",
-                title: name + "회원은 <br/>존재하지 않습니다!",
+                title: searchName + "회원은 <br/>존재하지 않습니다!",
               });
             }
           });
@@ -140,19 +149,33 @@ function MemberManage() {
     });
   };
 
-  const modifyUserCardinalHandler = (username, userId, generation) => {
+  const modifyUserInfoHandler = (
+    userId,
+    username,
+    studentId,
+    email,
+    generation
+  ) => {
     checkExpiredAccesstoken().then((response) => {
       Swal.fire({
         icon: "info",
-        title: `${username} 사용자를\n${generation}기 회원으로\n변경하시겠습니까?`,
+        title: `${username} 사용자의 회원정보를\n변경하시겠습니까?`,
         showDenyButton: true,
+        confirmButtonColor: "#4880ee",
+        denyButtonColor: "#a7a7a7",
         confirmButtonText: "네",
         denyButtonText: `아니요`,
       }).then(async (response) => {
         if (response.isConfirmed) {
           try {
             await api
-              .patch(`/api/users/${userId}/generation`, { generation })
+              .patch(`/api/v2/user/info/`, {
+                email,
+                generation,
+                studentId,
+                userId,
+                username,
+              })
               .then((result) => {
                 searchAllUsers();
                 Swal.fire({
@@ -161,17 +184,10 @@ function MemberManage() {
                 });
               });
           } catch (error) {
-            if (error.response.status === 406) {
-              Swal.fire({
-                icon: "error",
-                title: `관리자 권한을 지닌\n사용자는 제거할 수 없습니다.`,
-              });
-            } else {
-              Swal.fire({
-                icon: "error",
-                title: "예기치 못 한 에러가 발생하였습니다.",
-              });
-            }
+            Swal.fire({
+              icon: "error",
+              title: "예기치 못 한 에러가 발생하였습니다.",
+            });
           }
         } else {
           return;
@@ -186,9 +202,9 @@ function MemberManage() {
         <input
           className="w-25"
           type={"text"}
-          value={name}
+          value={searchName}
           onChange={(res) => {
-            setName(res.target.value);
+            setSearchName(res.target.value);
           }}
           placeholder="이름을 입력해주세요."
         ></input>
@@ -207,73 +223,226 @@ function MemberManage() {
         <table>
           <thead>
             <tr>
-              <th>이름</th>
-              <th>학번</th>
-              <th>이메일</th>
-              <th>기수</th>
+              <th style={{ width: "8rem" }}>이름</th>
+              <th style={{ width: "9rem" }}>학번</th>
+              <th style={{ width: "20rem" }}>이메일</th>
+              <th style={{ width: "5rem" }}>기수</th>
               <th>회원권한</th>
+              <th>정보변경</th>
               <th>회원제거</th>
             </tr>
           </thead>
 
           <tbody>
-            {members.map((member, i) => {
+            {members.map((member, idx) => {
               return (
-                <tr key={i}>
-                  <td>{member.username}</td>
-                  <td>{member.studentId}</td>
-                  <td>{member.email}</td>
-                  <td>
-                    <input
-                      type="number"
-                      placeholder={member.generation}
-                      onChange={(e) => {
-                        if (e.target.value < 0) e.target.value = 0;
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.keyCode === 13)
-                          modifyUserCardinalHandler(
-                            member.username,
-                            member.userId,
-                            e.target.value
-                          );
-                      }}
-                      style={{
-                        height: "1.5rem",
-                        fontSize: "15px",
-                        color: "black",
-                        borderRadius: "2.5px",
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <select
-                      className="authorityKinds text-center"
-                      value={member.role}
-                      onChange={(res) => {
-                        changeAuthority(
-                          member.userId,
-                          member.username,
-                          res.target.value,
-                          i
-                        );
-                      }}
-                    >
-                      <option value="ROLE_TEMP">미지정</option>
-                      <option value="ROLE_MEMBER">회원</option>
-                      <option value="ROLE_ADMIN">관리자</option>
-                    </select>
-                  </td>
-                  <td>
-                    <button
-                      className="text-bg-danger"
-                      onClick={(response) => {
-                        userRemoveHandler(member.username, member.userId);
-                      }}
-                    >
-                      추방
-                    </button>
-                  </td>
+                <tr key={idx}>
+                  {member.userInfoModifyMode ? (
+                    <>
+                      <td>
+                        <input
+                          className="usernameInput"
+                          type="text"
+                          value={member.username}
+                          onChange={(e) => {
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    username: e.target.value,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="studentIdInput"
+                          type="text"
+                          value={member.studentId}
+                          onChange={(e) => {
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    studentId: e.target.value,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="emailInput"
+                          type="text"
+                          value={member.email}
+                          onChange={(e) => {
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    email: e.target.value,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          value={member.generation}
+                          onChange={(e) => {
+                            if (e.target.value < 0) e.target.value = 0;
+                          }}
+                          style={{
+                            height: "1.5rem",
+                            fontSize: "15px",
+                            color: "black",
+                            borderRadius: "2.5px",
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <select
+                          className="authorityKinds text-center"
+                          value={member.role}
+                          disabled={true}
+                          onChange={(res) => {
+                            changeAuthority(
+                              member.userId,
+                              member.username,
+                              res.target.value,
+                              idx
+                            );
+                          }}
+                        >
+                          <option value="ROLE_TEMP">미지정</option>
+                          <option value="ROLE_MEMBER">회원</option>
+                          <option value="ROLE_ADMIN">관리자</option>
+                        </select>
+                      </td>
+                      <td>
+                        <button
+                          className="saveModifedUserInfo"
+                          onClick={(e) => {
+                            modifyUserInfoHandler(
+                              member.userId,
+                              member.username,
+                              member.studentId,
+                              member.email,
+                              member.generation
+                            );
+                          }}
+                        >
+                          저장
+                        </button>
+                        <button
+                          className="modifyUserInfoCancleButton"
+                          onClick={(response) => {
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    userInfoModifyMode:
+                                      !member.userInfoModifyMode,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
+                          }}
+                        >
+                          취소
+                        </button>
+                      </td>
+                      <td>
+                        <button
+                          className="text-bg-danger"
+                          onClick={(response) => {
+                            userRemoveHandler(member.username, member.userId);
+                          }}
+                        >
+                          추방
+                        </button>
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="usernameInput">{member.username}</td>
+                      <td className="studentIdInput">{member.studentId}</td>
+                      <td>{member.email}</td>
+                      <td className="emailInput">
+                        {member.generation ? member.generation : "정보없음"}
+                      </td>
+                      <td>
+                        <select
+                          className="authorityKinds text-center"
+                          value={member.role}
+                          onChange={(res) => {
+                            changeAuthority(
+                              member.userId,
+                              member.username,
+                              res.target.value,
+                              idx
+                            );
+                          }}
+                        >
+                          <option value="ROLE_TEMP">미지정</option>
+                          <option value="ROLE_MEMBER">회원</option>
+                          <option value="ROLE_ADMIN">관리자</option>
+                        </select>
+                      </td>
+                      <td>
+                        <button
+                          className="modifyUserInfoButton"
+                          onClick={(response) => {
+                            const updatedItems = members.map(
+                              (prevMembersInfo) => {
+                                if (prevMembersInfo.userId === member.userId) {
+                                  return {
+                                    ...prevMembersInfo,
+                                    userInfoModifyMode:
+                                      !member.userInfoModifyMode,
+                                  };
+                                }
+                                return prevMembersInfo;
+                              }
+                            );
+                            setMembers(updatedItems);
+                          }}
+                        >
+                          변경
+                        </button>
+                      </td>
+                      <td>
+                        <button
+                          className="text-bg-danger"
+                          onClick={(response) => {
+                            userRemoveHandler(member.username, member.userId);
+                          }}
+                        >
+                          추방
+                        </button>
+                      </td>
+                    </>
+                  )}
                 </tr>
               );
             })}

--- a/src/pages/management/MemberManage.scss
+++ b/src/pages/management/MemberManage.scss
@@ -33,7 +33,6 @@
     font-size: 1.2em;
     & > button {
       padding-left: 17px !important;
-      line-height: 1.5rem;
       border: 1px solid rgb(224, 224, 224);
       letter-spacing: 1rem;
       border-radius: 5px;
@@ -41,12 +40,42 @@
       padding: 0;
       font-size: 13px;
       width: 5rem;
-      height: 1.5rem;
+      height: 1.75rem;
     }
+
+    .modifyUserInfoButton {
+      background-color: rgb(136, 136, 136);
+    }
+
+    .saveModifedUserInfo {
+      background-color: rgb(97, 97, 247);
+    }
+
+    .modifyUserInfoCancleButton {
+      float: left;
+      margin-top: 0.1rem;
+      background-color: rgb(198, 198, 198);
+    }
+
     & > input {
+      color: black;
+      margin-left: -0.25rem;
       width: 3rem;
-      height: 2rem;
-      border: 1px solid black;
+      font-size: 16px;
+      height: 1.5rem;
+      border-radius: 5px;
+      border: 1px solid rgb(202, 202, 202);
+    }
+
+    .usernameInput {
+      width: 5rem;
+    }
+    .studentIdInput {
+      width: 7rem;
+    }
+
+    .emailInput {
+      width: 12rem;
     }
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #280 

## 📌 개요

현재 프로젝트 계획 상, 일반 유저의 경우 비밀번호를 제외한 별도의 개인정보 수정이
불가하기 때문에 관리자가 홈페이지 내 가입되어 있는 회원들의 정보를 변경할 수 있도록
별도의 UI 요소를 관리자페이지 회원 탭 페이지 내에 추가하였습니다.

## 👩‍💻 작업 사항

- 관리자페이지 `회원 탭`에 회원명, 이메일, 학번을 수정할 수 있는 UI가 추가됩니다.

## ✅ 참고 사항

- 현재 관리자 페이지 내 `회원 관리` 탭
<img width="1157" alt="Screenshot 2023-03-07 at 6 45 09 PM" src="https://user-images.githubusercontent.com/56868605/223385447-490d5ddc-414c-4517-9ddc-4738582f316c.png">

- 기능 추가 후 `회원 관리` 탭

![ezgif com-video-to-gif (9)](https://user-images.githubusercontent.com/56868605/223482281-48f1f55d-1fd8-4bf4-a344-a31eaf6c4d70.gif)