### PR TITLE
[fix]: 동아리 사진첩 컴포넌트 내 Pagination UI 위치 조정 (#284)

### DIFF
--- a/src/pages/photo/PhotoList.jsx
+++ b/src/pages/photo/PhotoList.jsx
@@ -95,54 +95,56 @@ const PhotoList = (props) => {
   };
 
   return (
-    <div className="photoMain" style={{ display: "flex" }}>
-      {loading ? (
-        <>
-          <Row>
-            {photoList.content.map((list, i) => {
-              let createDt = list.createDt.slice(0, 10);
-              return (
-                <Col key={i}>
-                  <div
-                    style={{ cursor: "pointer" }}
-                    onClick={() => {
-                      onClickDetail(list);
-                    }}
-                    className="eachPost shadow"
-                  >
-                    <span className="hoverViewCnt">
-                      Views <span>{list.viewCnt}</span>
-                    </span>
-                    <img
-                      alt="사진첩 사진"
-                      src={
-                        process.env.REACT_APP_URL +
-                        "/no-permit/api/boards/" +
-                        boardId +
-                        "/articles/" +
-                        list.id +
-                        "/files/" +
-                        list.files[0].filePath
-                      }
-                      style={{
-                        width: "100%",
-                        height: "100%",
+    <div>
+      <div className="photoMain" style={{ display: "flex" }}>
+        {loading ? (
+          <>
+            <Row>
+              {photoList.content.map((list, i) => {
+                let createDt = list.createDt.slice(0, 10);
+                return (
+                  <Col key={i}>
+                    <div
+                      style={{ cursor: "pointer" }}
+                      onClick={() => {
+                        onClickDetail(list);
                       }}
-                    ></img>
-                    <br />
-                    <br />
-                    <strong>{list.title}</strong>
-                    <hr />
-                    <span>
-                      {list.author} | {createDt}
-                    </span>
-                  </div>
-                </Col>
-              );
-            })}
-          </Row>
-        </>
-      ) : null}
+                      className="eachPost shadow"
+                    >
+                      <span className="hoverViewCnt">
+                        Views <span>{list.viewCnt}</span>
+                      </span>
+                      <img
+                        alt="사진첩 사진"
+                        src={
+                          process.env.REACT_APP_URL +
+                          "/no-permit/api/boards/" +
+                          boardId +
+                          "/articles/" +
+                          list.id +
+                          "/files/" +
+                          list.files[0].filePath
+                        }
+                        style={{
+                          width: "100%",
+                          height: "100%",
+                        }}
+                      ></img>
+                      <br />
+                      <br />
+                      <strong>{list.title}</strong>
+                      <hr />
+                      <span>
+                        {list.author} | {createDt}
+                      </span>
+                    </div>
+                  </Col>
+                );
+              })}
+            </Row>
+          </>
+        ) : null}
+      </div>
       <div className="pageNum">
         <Pagination>
           <Pagination.First onClick={() => onChangingPage("first")} />

--- a/src/pages/photo/PhotoList.scss
+++ b/src/pages/photo/PhotoList.scss
@@ -1,7 +1,7 @@
 .photoMain {
   background-color: rgb(255, 255, 255);
   justify-content: center;
-  padding-bottom: 5rem;
+  padding-bottom: 3rem;
 
   .row {
     display: grid;
@@ -45,15 +45,6 @@
     text-decoration: underline;
   }
 
-  .pageNum {
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    .pagination > li:first-child {
-      margin-top: 13.5px;
-    }
-  }
-
   @media (max-width: 1300px) {
     .row {
       grid-template-columns: repeat(3, 1fr);
@@ -70,5 +61,13 @@
     .row {
       grid-template-columns: repeat(1, 1fr);
     }
+  }
+}
+
+.pageNum {
+  display: flex;
+  justify-content: center;
+  .pagination > li:first-child {
+    margin-top: 12.5px;
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #284 

## 📌 개요

현재 홈페이지 내 `동아리 사진첩 컴포넌트`에 Pagination UI가 상단에 위치해
있는데, 게시글 내용과의 간격이 너무 좁아 불안정해 보이는 문제가 있었고,
다른 컴포넌트에서는 컴포넌트 내용 하단에 위치해 있고, 일반적으로
다른 홈페이지들의 경우에도 컴포넌트의 내용 하단에 위치해 있는 경우가 많아
기존 상단에서 하단으로 위치를 조정하였습니다.

## 👩‍💻 작업 사항

- `PhotoList.js` 컴포넌트 내 `Pagination UI` 관련 요소 div 태그 분할
- `PhotoList.scss` 파일 내 `Pagination UI` 요소의 위치 조정을 위한 스타일 속성 변경

## ✅ 참고 사항

- 현재 동아리 사진첩 컴포넌트 내 Paginiation UI 위치 (게시글 내용 상단에 배치된 상태)

![Screenshot 2023-03-21 at 8 32 36 PM](https://user-images.githubusercontent.com/56868605/226831682-7bd2ac3d-61f0-4d6d-92e4-2d4356fc9121.png)

- 수정 후 동아리 사진첩 컴포넌트 내 Paginiation UI 위치 (게시글 내용 하단으로 배치)

<img width="1322" alt="Screenshot 2023-03-22 at 4 33 44 PM" src="https://user-images.githubusercontent.com/56868605/226833529-9db34a94-bce2-4d13-bfd5-bd8dbf22db96.png">