### PR TITLE
[bug]: JWT Accesstoken 만료 후 로그아웃 버튼 클릭 시 기능이 작동되지 않는 버그 제거 (#286)

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -60,16 +60,27 @@ export async function checkExpiredAccesstoken() {
 }
 
 export async function signout() {
-  try {
-    return await api
-      .delete(process.env.REACT_APP_URL + "/auth/logout")
-      .then((response) => {
-        if (response.status === 200) {
-          localStorage.clear();
+  return await api
+    .delete(process.env.REACT_APP_URL + "/auth/logout")
+    .then((response) => {
+      if (response.status === 200) {
+        localStorage.clear();
+        window.location.href = "/";
+      }
+    })
+    .catch((error) => {
+      switch (error.response.status) {
+        case 400:
+        case 401:
           window.location.href = "/";
-        }
-      });
-  } catch (e) {}
+          break;
+        default:
+          Swal.fire({
+            icon: "error",
+            title: "예기치 못 한 에러가 발생하였습니다.",
+          });
+      }
+    });
 }
 
 export async function reissue(accessToken, refreshToken) {


### PR DESCRIPTION
## 👀 이슈

resolve #286 

## 📌 개요

현재 홈페이지에 로그인 함으로써 발급되는 JWT `Accesstoken`의 유효기간이
만료된 후 별도의 새로고침 동작 없이 로그아웃 버튼을 누를 시 기능이 정상적으로
작동되지 않는 버그가 발견되어 해당 문제를 제거하였습니다.

## 👩‍💻 작업 사항

- `useAuth.js` 내 signout 함수를 Client의 JWT Accesstoken이 만료된 상태에서
호출하게 되면, `Unauthorized(401)` 에러가 발생하여 해당 에러가 발생하는 경우에는
새로고침을 통해 로컬 스토리지에 존재하던 `만료된 accesstoken`과 초기 `유효기간`이
저장된 데이터를 지움으로써 해당 버그를 제거합니다.

## ✅ 참고 사항

- 해당 버그

![ezgif com-video-to-gif (11)](https://user-images.githubusercontent.com/56868605/227377552-bda6a408-c23a-473d-877f-9d87850f8ac5.gif)

- 버그 제거 후(JWT Accesstken의 유효기간 만료 전/후 모두 정상적으로 로그아웃 기능이 수행됨)

![ezgif com-video-to-gif (13)](https://user-images.githubusercontent.com/56868605/227383368-22f30b62-d97a-4bcf-a1c9-b43ea5b2bef9.gif)

![ezgif com-video-to-gif (15)](https://user-images.githubusercontent.com/56868605/227383973-b9fe595f-d822-41e2-bd6f-6e83d2f01a49.gif)
