### PR TITLE
[fix]: 회원가입 컴포넌트 내 '인증번호 요청' 버튼 클릭 시 인증번호 발송 여부 확인 메시지 초기화 및 인증코드 유효시간 표시 (#289)

### DIFF
--- a/src/pages/register/RegisterPage.scss
+++ b/src/pages/register/RegisterPage.scss
@@ -174,6 +174,19 @@
           border: 1px solid rgb(189, 191, 197);
         }
 
+        .emailValidationTime,
+        .emailValidationTimeOver {
+          font-size: 15px;
+          display: flex;
+          align-items: center;
+          position: relative;
+          left: 0.75rem;
+        }
+
+        .emailValidationTimeOver {
+          color: red;
+        }
+
         .eachContent:nth-child(1) {
           margin-bottom: 0.4rem;
           label {


### PR DESCRIPTION
## 👀 이슈

resolve #289 

## 📌 개요

현재 회원가입 컴포넌트 내에 있는 `인증번호 요청` 버튼 클릭 시
별도의 알림창과 메일이 성공적으로 발송되었을 때 이메일 입력란
하단에 인증번호 발송 요청에 대한 확인 메시지가 나타나도록 설계
되어있는데, 사용자가 `인증번호 요청` 버튼을 다시 클릭하였을 때
이전의 인증번호 요청에 대한 확인 메시지가 계속 표시되어 있어 사용자의
입장에서 새로 요청한 인증번호에 대한 확인 메시지인 것인지 혼동이 있을 수 있다고
판단되어 `인증번호 요청` 버튼을 클릭 시 이전의 이메일 입력란 하단의 확인 메시지가
초기화되도록 수정하고자 하였고, 추가적으로 이메일 인증코드 요청 시 버튼 우측에
인증코드의 유효시간을 나타내주고자 하였습니다.

## 👩‍💻 작업 사항

- `RegisterPage.jsx` 파일 수정
- 인증코드 유효시간 UI 요소 추가
- 부적절한 이메일 형식으로 `인증코드 요청` 버튼 클릭 시 관련 안내 문구 추가
- `RegisterPage.scss` 내 인증코드 유효시간 관련 UI 요소 스타일 적용

## ✅ 참고 사항

- 이전의 `인증번호 요청` 버튼 클릭 시 이전 요청에 대한 확인 메시지가 잔존하던 상태

![ezgif com-resize (27)](https://user-images.githubusercontent.com/56868605/229338211-29122686-29e3-408f-a24d-4f53dc5f09c8.gif)

- 기능 수정 후(확인 메시지 잔존 이슈 해결 및 인증코드 유효시간 UI 표시)

![ezgif com-resize (24)](https://user-images.githubusercontent.com/56868605/229338035-3d0d32c5-c632-4f7b-9169-b321326df19e.gif)

- 인증코드 유효시간 만료 후 안내 문구 추가
![ezgif com-resize (26)](https://user-images.githubusercontent.com/56868605/229338136-2bff62ba-e76b-444e-afe0-bebe96c9ed4e.gif)

- 부적절한 이메일 형식으로 `인증코드 요청` 버튼 클릭 시 관련 안내 문구 추가

![ezgif com-resize (25)](https://user-images.githubusercontent.com/56868605/229338080-5e7737d6-9aa9-4380-a22a-37e384cbf102.gif)