### PR TITLE
[fix]: 이메일 인증번호 유효 시간 정정 (#289)

### DIFF
--- a/src/pages/register/RegisterPage.jsx
+++ b/src/pages/register/RegisterPage.jsx
@@ -24,7 +24,7 @@ function RegisterPage() {
   const TIMER_STATE_OVER = "timerStateOver";
 
   // 이메일 인증번호 유효 시간: 60(초[s]=) * 5 = 5(분[m])
-  const emailValidationTimeValue = 15;
+  const emailValidationTimeValue = 60 * 5;
 
   const [userInfo, setUserInfo] = useState({
     studentId: "",


### PR DESCRIPTION
## 👀 이슈

resolve #291 

## 📌 개요

현재 회원가입 시 이메일 인증번호의 유효시간이 5분으로 설정되어 있는데,
홈페이지의 인증번호 유효시간 표시란에는 15초로 설정되어 있어서 해당 부분을
알맞게 정정하고자 하였습니다.

## 👩‍💻 작업 사항

- `RegisterPage.jsx` 파일 수정

## ✅ 참고 사항

없습니다