### PR TITLE
[feat]: 회원관리 컴포넌트 내 회원목록 정렬 기능 추가 (#297)

### DIFF
--- a/src/pages/management/MemberManage.scss
+++ b/src/pages/management/MemberManage.scss
@@ -1,6 +1,18 @@
 #MemberManage {
   margin: 0 5%;
   margin-right: 20%;
+
+  .sortSection {
+    margin-top: 2rem;
+    .sortingCriteriaTitle {
+      margin-right: 0.5rem;
+    }
+
+    select {
+      width: 6rem !important;
+    }
+  }
+
   input {
     margin-top: 2%;
     width: 20%;


### PR DESCRIPTION
## 👀 이슈

resolve #297 

## 📌 개요

현재 관리자 페이지 내 `회원관리` 컴포넌트 안에 나타나는
회원 리스트를 특정 기준이 선택되었을 때 그에 알맞게 리스트가
정렬되도록 해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `회원관리` 컴포넌트 내 회원 목록을 특정 기준에 맞게 정렬할 수 있도록 기능하는 요소 추가
(학번순`(기본)`, 회원가입순, 이름순, 권한순)

## ✅ 참고 사항

- 이전 `회원관리` 컴포넌트 UI

<img width="1180" alt="Screenshot 2023-04-26 at 10 10 12 PM" src="https://user-images.githubusercontent.com/56868605/234585171-5b4694b1-6818-4d3e-a322-1df338f1c659.png">

- 회원 목록 정렬 기능 추가 후

![ezgif com-video-to-gif (19)](https://user-images.githubusercontent.com/56868605/234894424-af5e7e80-a917-48e5-a634-577f88ebed00.gif)